### PR TITLE
GtkWindow: set min, max and default sizes

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -18,7 +18,11 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window = handy_window_new(GTK_APPLICATION(application));
   gtk_window_set_title(window, "Firmware Updater");
 
-  gtk_window_set_default_size(window, 1280, 720);
+  GdkGeometry geometry;
+  geometry.min_width = 600;
+  geometry.min_height = 700;
+  gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
+  gtk_window_set_default_size(window, 700, 850);
   gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();


### PR DESCRIPTION
|  | Before | After |
| --- | --- | --- |
| Default Size | ![Bildschirmfoto von 2022-01-31 18-54-18](https://user-images.githubusercontent.com/15329494/151846926-5e33d337-d337-4d51-8a77-070d4ffa925c.png) | ![Bildschirmfoto von 2022-01-31 18-51-09](https://user-images.githubusercontent.com/15329494/151847013-8b3aeb65-dd39-4ae2-b373-c94e9dd4416a.png) |
| Min Size | ![Bildschirmfoto von 2022-01-31 18-54-25](https://user-images.githubusercontent.com/15329494/151847201-c15e18dc-3eb3-4575-b7db-4a09246f7ad8.png) | ![Bildschirmfoto von 2022-01-31 18-51-18](https://user-images.githubusercontent.com/15329494/151847200-343b05eb-2f52-467f-9ebb-0dcefa6412e7.png) |





Closes #3 