### PR TITLE
Add integration test based on fwupd-tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,14 +30,20 @@ jobs:
     - run: flutter test
 
   integration:
-    if: ${{false}}
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
     - run: sudo apt update
-    - run: sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip xvfb
+    - run: sudo apt install -y clang cmake curl dbus dbus-x11 fwupd fwupd-tests gsettings-desktop-schemas libgtk-3-dev ninja-build pkg-config unzip xvfb
       env:
         DEBIAN_FRONTEND: noninteractive
-    - run: xvfb-run -a xvfb-run -a -s '-screen 0 1024x768x24 +extension GLX' \
-            flutter test integration_test
+    - name: Prepare environment
+      run: |
+        sudo sed -i 's/DisabledPlugins=.*/DisabledPlugins=invalid;bios/g' /etc/fwupd/daemon.conf
+        echo "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$UID/bus" >> $GITHUB_ENV
+        echo "XDG_RUNTIME_DIR=/run/user/$UID" >> $GITHUB_ENV
+        gsettings set org.gnome.desktop.interface gtk-theme 'Yaru'
+    - run: sudo fwupdmgr enable-remote fwupd-tests
+    - run: sudo fwupdmgr get-devices
+    - run: sudo -E xvfb-run -a -s '-screen 0 1024x768x24 +extension GLX' $FLUTTER_ROOT/bin/flutter test integration_test

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,0 +1,35 @@
+### Fake webcam
+
+Install `fwupd-tests`:
+```sh
+sudo apt install fwupd-tests
+```
+Notice the instructions at the end:
+```
+...
+Setting up fwupd-tests (x.y.z) ...
+To enable test suite, modify /etc/fwupd/daemon.conf
+To enable test suite, enable fwupd-tests remote
+```
+
+Modify `/etc/fwupd/daemon.conf`:
+```diff
+diff --git a/etc/fwupd/daemon.conf b/etc/fwupd/daemon.conf
+index 6ac8252..388a175 100644
+--- a/etc/fwupd/daemon.conf
++++ b/etc/fwupd/daemon.conf
+@@ -6,7 +6,7 @@ DisabledDevices=
+ 
+ # Allow blocking specific plugins
+ # Uses semicolons as delimiter
+-DisabledPlugins=test;test_ble;invalid
++DisabledPlugins=invalid
+ 
+ # Maximum archive size that can be loaded in Mb, with 0 for the default
+ ArchiveSizeMax=0
+```
+
+Enable `fwupd-tests` remote:
+```sh
+fwupdmgr enable-remote fwupd-tests
+```

--- a/integration_test/firmware_updater_test.dart
+++ b/integration_test/firmware_updater_test.dart
@@ -1,0 +1,192 @@
+import 'package:collection/collection.dart';
+import 'package:firmware_updater/fwupd_x.dart';
+import 'package:firmware_updater/main.dart' as app;
+import 'package:firmware_updater/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fwupd/fwupd.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../test/test_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final client = FwupdClient();
+  setUpAll(client.connect);
+  tearDownAll(client.close);
+
+  group('fake webcam', () {
+    testWidgets('upgrade', (tester) async {
+      final webcam = await client.findDevice((d) => d.summary == 'Fake webcam');
+      expect(webcam, isNotNull, reason: 'Install fwupd-tests (Fake webcam).');
+
+      final upgrade = await client.findRelease(webcam!, (r) => r.isUpgrade);
+      expect(upgrade, isNotNull, reason: 'Fake webcam has no upgrades');
+      expect(upgrade!.version, isNotEmpty);
+
+      app.main();
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapDeviceHeader('Fake webcam');
+      await tester.pumpAndSettle();
+
+      expect(find.deviceBody(upgrade.version), findsNothing);
+
+      await tester.pumpAndTapButton(tester.lang.showUpdates);
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapReleaseCard(upgrade.version);
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapButton(tester.lang.upgrade);
+      await client.testInstallation(webcam, upgrade);
+    });
+
+    testWidgets('reinstall', (tester) async {
+      final webcam = await client.findDevice((d) => d.summary == 'Fake webcam');
+      expect(webcam, isNotNull, reason: 'Install fwupd-tests (Fake webcam).');
+
+      final reinstall = await client.findRelease(
+        webcam!,
+        (r) => !r.isDowngrade && !r.isUpgrade,
+      );
+      expect(reinstall, isNotNull, reason: 'Fake webcam has no reinstall');
+      expect(reinstall!.version, isNotEmpty);
+
+      app.main();
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapDeviceHeader('Fake webcam');
+      await tester.pumpAndSettle();
+
+      expect(find.deviceBody(reinstall.version), findsOneWidget);
+
+      await tester.pumpAndTapButton(tester.lang.showReleases);
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapReleaseCard(reinstall.version);
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapButton(tester.lang.reinstall);
+      await client.testInstallation(webcam, reinstall);
+    });
+
+    testWidgets('downgrade', (tester) async {
+      final webcam = await client.findDevice((d) => d.summary == 'Fake webcam');
+      expect(webcam, isNotNull, reason: 'Install fwupd-tests (Fake webcam).');
+
+      final downgrade = await client.findRelease(webcam!, (r) => r.isDowngrade);
+      expect(downgrade, isNotNull, reason: 'Fake webcam has no downgrades');
+      expect(downgrade!.version, isNotEmpty);
+
+      app.main();
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapDeviceHeader('Fake webcam');
+      await tester.pumpAndSettle();
+
+      expect(find.deviceBody(downgrade.version), findsNothing);
+
+      await tester.pumpAndTapButton(tester.lang.showReleases);
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapReleaseCard(downgrade.version);
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapButton(tester.lang.downgrade);
+      await client.testInstallation(webcam, downgrade);
+    });
+  });
+}
+
+extension IntegrationClient on FwupdClient {
+  Future<FwupdDevice?> findDevice(bool Function(FwupdDevice) test) {
+    return getDevices().then((d) => d.firstWhereOrNull(test));
+  }
+
+  Future<FwupdRelease?> findRelease(
+    FwupdDevice device,
+    bool Function(FwupdRelease) test,
+  ) {
+    return getReleases(device.deviceId).then((r) => r.firstWhereOrNull(test));
+  }
+
+  Future<void> testInstallation(
+    FwupdDevice device,
+    FwupdRelease release, [
+    Duration timeout = const Duration(seconds: 60),
+  ]) async {
+    await expectLater(
+      propertiesChanged
+          .where((p) => p.contains('Status'))
+          .map((_) => status.isBusy)
+          .timeout(timeout),
+      emits(true),
+    );
+
+    if (percentage < 100) {
+      await expectLater(
+        propertiesChanged
+            .where((p) => p.contains('Percentage'))
+            .map((_) => percentage)
+            .timeout(timeout),
+        emitsThrough(100),
+      );
+    }
+
+    if (status.isBusy) {
+      await expectLater(
+        propertiesChanged
+            .where((p) => p.contains('Status'))
+            .map((_) => status.isBusy)
+            .timeout(timeout),
+        emitsThrough(false),
+      );
+    }
+
+    final updateState = await findDevice((d) =>
+            d.deviceId == device.deviceId && d.version == release.version)
+        .then((d) => d!.updateState);
+    if (updateState != FwupdUpdateState.success) {
+      await expectLater(
+        deviceChanged
+            .where((d) =>
+                d.deviceId == device.deviceId && d.version == release.version)
+            .map((d) => d.updateState),
+        emitsThrough(FwupdUpdateState.success),
+      );
+    }
+  }
+}
+
+extension IntegrationTester on WidgetTester {
+  Future<void> pumpAndTapDeviceHeader(String text) async {
+    final header = find.deviceHeader(text);
+    await pumpUntil(header);
+    return tap(header);
+  }
+
+  Future<void> pumpAndTapButton(String text) async {
+    final button = find.ancestor(
+      of: find.text(text),
+      matching: find.byWidgetPredicate((widget) => widget is ButtonStyleButton),
+    );
+    if (button.evaluate().length > 1) {
+      debugPrint('WARNING: Multiple "$text" buttons. Assuming the first.');
+    }
+    await pumpUntil(button.first);
+    return tap(button.first);
+  }
+
+  Future<void> pumpAndTapReleaseCard(String version) async {
+    final card = find.widgetWithText(ReleaseCard, version);
+    await pumpUntil(card);
+    return tap(card);
+  }
+}
+
+extension IntegrationFinder on CommonFinders {
+  Finder deviceHeader(String text) => find.widgetWithText(DeviceHeader, text);
+  Finder deviceBody(String text) => find.widgetWithText(DeviceBody, text);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^2.1.0+1
+  integration_test:
+    sdk: flutter
   mockito: 5.3.0
 
 flutter:

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -58,4 +58,24 @@ extension WidgetTesterX on WidgetTester {
       home: Builder(builder: builder),
     ));
   }
+
+  Future<void> pumpUntil(
+    Finder finder, [
+    Duration timeout = const Duration(seconds: 30),
+  ]) async {
+    assert(timeout.inMilliseconds >= 250);
+    const delay = Duration(milliseconds: 250);
+
+    if (this.any(finder)) return;
+
+    return Future.doWhile(() async {
+      if (this.any(finder)) return false;
+      await pump(delay);
+      return true;
+    }).timeout(
+      timeout,
+      onTimeout: () => debugPrint(
+          '\nWARNING: A call to pumpUntil() with finder "$finder" did not complete within the specified timeout $timeout.\n${StackTrace.current}'),
+    );
+  }
 }


### PR DESCRIPTION
### Fake webcam

Install `fwupd-tests`:
```sh
sudo apt install fwupd-tests
```
Notice the instructions at the end:
```
...
Setting up fwupd-tests (x.y.z) ...
To enable test suite, modify /etc/fwupd/daemon.conf
To enable test suite, enable fwupd-tests remote
```

Modify `/etc/fwupd/daemon.conf`:
```diff
diff --git a/etc/fwupd/daemon.conf b/etc/fwupd/daemon.conf
index 6ac8252..388a175 100644
--- a/etc/fwupd/daemon.conf
+++ b/etc/fwupd/daemon.conf
@@ -6,7 +6,7 @@ DisabledDevices=
 
 # Allow blocking specific plugins
 # Uses semicolons as delimiter
-DisabledPlugins=test;test_ble;invalid
+DisabledPlugins=invalid
 
 # Maximum archive size that can be loaded in Mb, with 0 for the default
 ArchiveSizeMax=0
```

Enable `fwupd-tests` remote:
```sh
fwupdmgr enable-remote fwupd-tests
```
