### PR TITLE
Master detail layout

### DIFF
--- a/lib/firmware_model.dart
+++ b/lib/firmware_model.dart
@@ -19,7 +19,7 @@ class FirmwareModel extends SafeChangeNotifier {
 
   final FwupdService _service;
   final FwupdNotifier _monitor;
-  var _state = FirmwareState.empty;
+  var _state = const FirmwareState.loading();
 
   FirmwareState get state => _state;
 

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -38,7 +38,6 @@ class _FirmwarePageState extends State<FirmwarePage> {
   @override
   Widget build(BuildContext context) {
     final model = context.watch<FirmwareModel>();
-    final fwupd = context.watch<FwupdNotifier>();
     return model.state.map(
       data: (state) => YaruMasterDetailPage(
         pageItems: state.devices

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
@@ -57,7 +58,7 @@ class _FirmwarePageState extends State<FirmwarePage> {
                     onInstall: (release) => model.install(device, release),
                     hasUpgrade: state.hasUpgrade(device),
                   ),
-                  iconData: YaruIcons.computer,
+                  iconData: DeviceIcon.fromName(device.icon.firstOrNull),
                 ))
             .toList(),
         leftPaneWidth: 400,

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -1,10 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:yaru_colors/yaru_colors.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'firmware_model.dart';

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_colors/yaru_colors.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'firmware_model.dart';
 import 'fwupd_notifier.dart';
@@ -39,43 +41,29 @@ class _FirmwarePageState extends State<FirmwarePage> {
   Widget build(BuildContext context) {
     final model = context.watch<FirmwareModel>();
     final fwupd = context.watch<FwupdNotifier>();
-    return Scaffold(
-      backgroundColor: Theme.of(context).brightness == Brightness.light
-          ? YaruColors.warmGrey.shade200
-          : null,
-      appBar: AppProgressBar(
-        title: AppLocalizations.of(context).appTitle,
-        height: ProgressIndicatorTheme.of(context).linearMinHeight,
-        status: fwupd.status,
-        progress: fwupd.percentage / 100,
-        onRefresh: model.refresh,
+    return model.state.map(
+      data: (state) => YaruMasterDetailPage(
+        pageItems: state.devices
+            .map((device) => YaruPageItem(
+                  titleBuilder: (context) => DeviceHeader(
+                    device: device,
+                    hasUpgrade: state.hasUpgrade(device),
+                  ),
+                  builder: (context) => DeviceBody(
+                    device: device,
+                    canVerify: device.canVerify,
+                    onVerify: () => model.verify(device),
+                    releases: state.getReleases(device) ?? [],
+                    onInstall: (release) => model.install(device, release),
+                    hasUpgrade: state.hasUpgrade(device),
+                  ),
+                  iconData: YaruIcons.computer,
+                ))
+            .toList(),
+        leftPaneWidth: 400,
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
-        child: model.state.map(
-          data: (state) => DevicePanelList(
-            devices: state.devices,
-            headerBuilder: (context, device, isExpanded) => DeviceHeader(
-              device: device,
-              hasUpgrade: state.hasUpgrade(device),
-            ),
-            bodyBuilder: (context, device, child) => DeviceBody(
-              device: device,
-              canVerify: device.canVerify,
-              hasUpgrade: state.hasUpgrade(device),
-              releases: state.getReleases(device) ?? [],
-              onVerify: () => model.verify(device),
-              onInstall: (release) => model.install(device, release),
-            ),
-          ),
-          loading: (state) => const Center(child: CircularProgressIndicator()),
-          error: (state) => ErrorWidget(state.error),
-        ),
-      ),
-      bottomNavigationBar: StatusBar(
-        status: fwupd.status,
-        daemonVersion: fwupd.version,
-      ),
+      loading: (state) => const Center(child: CircularProgressIndicator()),
+      error: (state) => ErrorWidget(state.error),
     );
   }
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -3,7 +3,8 @@
   "close": "Close",
   "current": "Current",
   "downgrade": "Downgrade",
-  "guid": "GUID",
+  "flags": "Flags",
+  "guid": "GUIDs",
   "reinstall": "Reinstall",
   "showReleases": "Show Releases",
   "showUpdates": "Show Updates",
@@ -11,5 +12,6 @@
   "upgrade": "Upgrade",
   "vendor": "Vendor",
   "verifyFirmware": "Verify Firmware",
-  "version": "Version"
+  "currentVersion": "Current Version",
+  "minVersion": "Minimum Version"
 }

--- a/lib/src/widgets/device_body.dart
+++ b/lib/src/widgets/device_body.dart
@@ -1,8 +1,10 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
 
+import 'device_icon.dart';
 import 'release_dialog.dart';
 import 'small_chip.dart';
 
@@ -45,100 +47,145 @@ class DeviceBody extends StatelessWidget {
     return _buildPadding(Text(text));
   }
 
+  static Widget _buildIconRow(
+    BuildContext context,
+    String vendor,
+    String name,
+    String description,
+    IconData icon,
+  ) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          size: 64,
+        ),
+        const SizedBox(width: 16),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              vendor,
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            Text(
+              name,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            Text(
+              description,
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return Padding(
-      padding: const EdgeInsets.only(top: 4, left: 16, right: 16, bottom: 16),
+      padding: const EdgeInsets.all(16),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Table(
-                columnWidths: const {
-                  0: IntrinsicColumnWidth(),
-                  1: FixedColumnWidth(16),
-                  2: IntrinsicColumnWidth(),
-                },
-                children: [
-                  if (device.version != null)
-                    TableRow(children: [
-                      DeviceBody._buildHeader(context, l10n.version),
-                      const SizedBox.shrink(),
-                      DeviceBody._buildLabel(context, device.version!),
-                    ]),
-                  if (device.vendor != null)
-                    TableRow(children: [
-                      DeviceBody._buildHeader(context, l10n.vendor),
-                      const SizedBox.shrink(),
-                      DeviceBody._buildLabel(context, device.vendor!),
-                    ]),
-                  if (device.guid.isNotEmpty)
-                    TableRow(children: [
-                      DeviceBody._buildHeader(context, l10n.guid),
-                      const SizedBox.shrink(),
-                      DeviceBody._buildPadding(
-                          SelectableText(device.guid.first)),
-                    ]),
-                  if (device.guid.length > 1)
-                    for (final guid in device.guid.skip(1))
-                      TableRow(children: [
-                        DeviceBody._buildHeader(context, ''),
-                        const SizedBox.shrink(),
-                        DeviceBody._buildPadding(SelectableText(guid)),
-                      ]),
-                ],
+              DeviceBody._buildIconRow(
+                context,
+                device.vendor ?? '',
+                device.name,
+                device.summary ?? '',
+                DeviceIcon.fromName(device.icon.firstOrNull),
               ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    alignment: WrapAlignment.end,
-                    children: [
-                      for (final flag in device.flags)
-                        SmallChip(text: describeEnum(flag)),
-                    ],
-                  ),
+              if (canVerify || releases.isNotEmpty) const Spacer(),
+              if (canVerify || releases.isNotEmpty)
+                ButtonBar(
+                  children: [
+                    if (canVerify)
+                      OutlinedButton(
+                        onPressed: onVerify,
+                        child: Text(l10n.verifyFirmware),
+                      ),
+                    if (releases.isNotEmpty)
+                      hasUpgrade
+                          ? ElevatedButton(
+                              onPressed: () => showReleaseDialog(
+                                context,
+                                device: device,
+                                releases: releases,
+                                onInstall: onInstall,
+                              ),
+                              child: Text(l10n.showUpdates),
+                            )
+                          : OutlinedButton(
+                              onPressed: () => showReleaseDialog(
+                                context,
+                                device: device,
+                                releases: releases,
+                                onInstall: onInstall,
+                              ),
+                              child: Text(l10n.showReleases),
+                            ),
+                  ],
                 ),
-              ),
             ],
           ),
-          if (canVerify || releases.isNotEmpty) const SizedBox(height: 16),
-          if (canVerify || releases.isNotEmpty)
-            ButtonBar(
-              children: [
-                if (canVerify)
-                  OutlinedButton(
-                    onPressed: onVerify,
-                    child: Text(l10n.verifyFirmware),
-                  ),
-                if (releases.isNotEmpty)
-                  hasUpgrade
-                      ? ElevatedButton(
-                          onPressed: () => showReleaseDialog(
-                            context,
-                            device: device,
-                            releases: releases,
-                            onInstall: onInstall,
-                          ),
-                          child: Text(l10n.showUpdates),
-                        )
-                      : OutlinedButton(
-                          onPressed: () => showReleaseDialog(
-                            context,
-                            device: device,
-                            releases: releases,
-                            onInstall: onInstall,
-                          ),
-                          child: Text(l10n.showReleases),
-                        ),
-              ],
-            ),
+          const SizedBox(height: 32),
+          Table(
+            columnWidths: const {
+              0: IntrinsicColumnWidth(),
+              1: FixedColumnWidth(16),
+              2: IntrinsicColumnWidth(),
+            },
+            children: [
+              if (device.version != null)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.currentVersion),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildLabel(context, device.version!),
+                ]),
+              if (device.versionLowest != null)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.minVersion),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildLabel(context, device.versionLowest!),
+                ]),
+              if (device.vendor != null)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.vendor),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildLabel(context, device.vendor!),
+                ]),
+              if (device.guid.isNotEmpty)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.guid),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildPadding(SelectableText(device.guid.first)),
+                ]),
+              if (device.guid.length > 1)
+                for (final guid in device.guid.skip(1))
+                  TableRow(children: [
+                    DeviceBody._buildHeader(context, ''),
+                    const SizedBox.shrink(),
+                    DeviceBody._buildPadding(SelectableText(guid)),
+                  ]),
+              if (device.flags.isNotEmpty)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.flags),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildPadding(
+                      Text(describeEnum(device.flags.first)))
+                ]),
+              if (device.flags.length > 1)
+                for (final flag in device.flags.skip(1))
+                  TableRow(children: [
+                    DeviceBody._buildHeader(context, ''),
+                    const SizedBox.shrink(),
+                    DeviceBody._buildPadding(Text(describeEnum(flag)))
+                  ]),
+            ],
+          ),
         ],
       ),
     );

--- a/lib/src/widgets/device_body.dart
+++ b/lib/src/widgets/device_body.dart
@@ -6,7 +6,6 @@ import 'package:fwupd/fwupd.dart';
 
 import 'device_icon.dart';
 import 'release_dialog.dart';
-import 'small_chip.dart';
 
 class DeviceBody extends StatelessWidget {
   const DeviceBody({

--- a/lib/src/widgets/device_body.dart
+++ b/lib/src/widgets/device_body.dart
@@ -86,106 +86,115 @@ class DeviceBody extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.all(16),
-      child: Column(
-        children: [
-          Row(
+      child: Scrollbar(
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              DeviceBody._buildIconRow(
-                context,
-                device.vendor ?? '',
-                device.name,
-                device.summary ?? '',
-                DeviceIcon.fromName(device.icon.firstOrNull),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  DeviceBody._buildIconRow(
+                    context,
+                    device.vendor ?? '',
+                    device.name,
+                    device.summary ?? '',
+                    DeviceIcon.fromName(device.icon.firstOrNull),
+                  ),
+                  if (canVerify || releases.isNotEmpty)
+                    const SizedBox(width: 16),
+                  if (canVerify || releases.isNotEmpty)
+                    ButtonBar(
+                      children: [
+                        if (canVerify)
+                          OutlinedButton(
+                            onPressed: onVerify,
+                            child: Text(l10n.verifyFirmware),
+                          ),
+                        if (releases.isNotEmpty)
+                          hasUpgrade
+                              ? ElevatedButton(
+                                  onPressed: () => showReleaseDialog(
+                                    context,
+                                    device: device,
+                                    releases: releases,
+                                    onInstall: onInstall,
+                                  ),
+                                  child: Text(l10n.showUpdates),
+                                )
+                              : OutlinedButton(
+                                  onPressed: () => showReleaseDialog(
+                                    context,
+                                    device: device,
+                                    releases: releases,
+                                    onInstall: onInstall,
+                                  ),
+                                  child: Text(l10n.showReleases),
+                                ),
+                      ],
+                    ),
+                ],
               ),
-              if (canVerify || releases.isNotEmpty) const Spacer(),
-              if (canVerify || releases.isNotEmpty)
-                ButtonBar(
-                  children: [
-                    if (canVerify)
-                      OutlinedButton(
-                        onPressed: onVerify,
-                        child: Text(l10n.verifyFirmware),
-                      ),
-                    if (releases.isNotEmpty)
-                      hasUpgrade
-                          ? ElevatedButton(
-                              onPressed: () => showReleaseDialog(
-                                context,
-                                device: device,
-                                releases: releases,
-                                onInstall: onInstall,
-                              ),
-                              child: Text(l10n.showUpdates),
-                            )
-                          : OutlinedButton(
-                              onPressed: () => showReleaseDialog(
-                                context,
-                                device: device,
-                                releases: releases,
-                                onInstall: onInstall,
-                              ),
-                              child: Text(l10n.showReleases),
-                            ),
-                  ],
-                ),
+              const SizedBox(height: 32),
+              Table(
+                columnWidths: const {
+                  0: IntrinsicColumnWidth(),
+                  1: FixedColumnWidth(16),
+                  2: IntrinsicColumnWidth(),
+                },
+                children: [
+                  if (device.version != null)
+                    TableRow(children: [
+                      DeviceBody._buildHeader(context, l10n.currentVersion),
+                      const SizedBox.shrink(),
+                      DeviceBody._buildLabel(context, device.version!),
+                    ]),
+                  if (device.versionLowest != null)
+                    TableRow(children: [
+                      DeviceBody._buildHeader(context, l10n.minVersion),
+                      const SizedBox.shrink(),
+                      DeviceBody._buildLabel(context, device.versionLowest!),
+                    ]),
+                  if (device.vendor != null)
+                    TableRow(children: [
+                      DeviceBody._buildHeader(context, l10n.vendor),
+                      const SizedBox.shrink(),
+                      DeviceBody._buildLabel(context, device.vendor!),
+                    ]),
+                  if (device.guid.isNotEmpty)
+                    TableRow(children: [
+                      DeviceBody._buildHeader(context, l10n.guid),
+                      const SizedBox.shrink(),
+                      DeviceBody._buildPadding(
+                          SelectableText(device.guid.first)),
+                    ]),
+                  if (device.guid.length > 1)
+                    for (final guid in device.guid.skip(1))
+                      TableRow(children: [
+                        DeviceBody._buildHeader(context, ''),
+                        const SizedBox.shrink(),
+                        DeviceBody._buildPadding(SelectableText(guid)),
+                      ]),
+                  if (device.flags.isNotEmpty)
+                    TableRow(children: [
+                      DeviceBody._buildHeader(context, l10n.flags),
+                      const SizedBox.shrink(),
+                      DeviceBody._buildPadding(
+                          Text(describeEnum(device.flags.first)))
+                    ]),
+                  if (device.flags.length > 1)
+                    for (final flag in device.flags.skip(1))
+                      TableRow(children: [
+                        DeviceBody._buildHeader(context, ''),
+                        const SizedBox.shrink(),
+                        DeviceBody._buildPadding(Text(describeEnum(flag)))
+                      ]),
+                ],
+              ),
             ],
           ),
-          const SizedBox(height: 32),
-          Table(
-            columnWidths: const {
-              0: IntrinsicColumnWidth(),
-              1: FixedColumnWidth(16),
-              2: IntrinsicColumnWidth(),
-            },
-            children: [
-              if (device.version != null)
-                TableRow(children: [
-                  DeviceBody._buildHeader(context, l10n.currentVersion),
-                  const SizedBox.shrink(),
-                  DeviceBody._buildLabel(context, device.version!),
-                ]),
-              if (device.versionLowest != null)
-                TableRow(children: [
-                  DeviceBody._buildHeader(context, l10n.minVersion),
-                  const SizedBox.shrink(),
-                  DeviceBody._buildLabel(context, device.versionLowest!),
-                ]),
-              if (device.vendor != null)
-                TableRow(children: [
-                  DeviceBody._buildHeader(context, l10n.vendor),
-                  const SizedBox.shrink(),
-                  DeviceBody._buildLabel(context, device.vendor!),
-                ]),
-              if (device.guid.isNotEmpty)
-                TableRow(children: [
-                  DeviceBody._buildHeader(context, l10n.guid),
-                  const SizedBox.shrink(),
-                  DeviceBody._buildPadding(SelectableText(device.guid.first)),
-                ]),
-              if (device.guid.length > 1)
-                for (final guid in device.guid.skip(1))
-                  TableRow(children: [
-                    DeviceBody._buildHeader(context, ''),
-                    const SizedBox.shrink(),
-                    DeviceBody._buildPadding(SelectableText(guid)),
-                  ]),
-              if (device.flags.isNotEmpty)
-                TableRow(children: [
-                  DeviceBody._buildHeader(context, l10n.flags),
-                  const SizedBox.shrink(),
-                  DeviceBody._buildPadding(
-                      Text(describeEnum(device.flags.first)))
-                ]),
-              if (device.flags.length > 1)
-                for (final flag in device.flags.skip(1))
-                  TableRow(children: [
-                    DeviceBody._buildHeader(context, ''),
-                    const SizedBox.shrink(),
-                    DeviceBody._buildPadding(Text(describeEnum(flag)))
-                  ]),
-            ],
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/src/widgets/device_header.dart
+++ b/lib/src/widgets/device_header.dart
@@ -1,9 +1,7 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
 
-import 'device_icon.dart';
 import 'small_chip.dart';
 
 class DeviceHeader extends StatelessWidget {

--- a/lib/src/widgets/device_header.dart
+++ b/lib/src/widgets/device_header.dart
@@ -24,7 +24,6 @@ class DeviceHeader extends StatelessWidget {
         ListTile(
           title: Text(device.name),
           subtitle: Text(device.summary ?? ''),
-          leading: DeviceIcon.fromName(device.icon.firstOrNull),
           contentPadding: const EdgeInsets.only(left: 24),
         ),
         if (hasUpgrade)

--- a/lib/src/widgets/device_icon.dart
+++ b/lib/src/widgets/device_icon.dart
@@ -44,12 +44,12 @@ const yaruIcons = <String, IconData>{
 
 // TODO: https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
 class DeviceIcon {
-  static Widget? fromName(String? name) {
+  static IconData fromName(String? name) {
     final icon = yaruIcons[name];
     if (icon == null && name != null) {
       debugPrint('Missing icon: $name');
-      return const SizedBox(width: 24, height: 24, child: Placeholder());
+      return YaruIcons.question;
     }
-    return Icon(icon ?? YaruIcons.computer);
+    return icon ?? YaruIcons.computer;
   }
 }

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -1,6 +1,7 @@
 export 'src/widgets/app_progress_bar.dart';
 export 'src/widgets/device_body.dart';
 export 'src/widgets/device_header.dart';
+export 'src/widgets/device_icon.dart';
 export 'src/widgets/device_panel_list.dart';
 export 'src/widgets/message_dialog.dart';
 export 'src/widgets/option_card.dart';

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -48,10 +48,10 @@ static void my_application_activate(GApplication* application) {
   }
 
   GdkGeometry geometry;
-  geometry.min_width = 600;
+  geometry.min_width = 800;
   geometry.min_height = 700;
   gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
-  gtk_window_set_default_size(window, 700, 850);
+  gtk_window_set_default_size(window, 1280, 720);
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(

--- a/test/firmare_page_test.dart
+++ b/test/firmare_page_test.dart
@@ -63,8 +63,9 @@ void main() {
     await tester
         .pumpApp((_) => buildPage(model: model, notifier: mockNotifier()));
 
-    expect(find.text('Device 1'), findsOneWidget);
-    expect(find.text('Summary 1'), findsOneWidget);
+    // First device appears twice in master detail layout
+    expect(find.text('Device 1'), findsNWidgets(2));
+    expect(find.text('Summary 1'), findsNWidgets(2));
 
     expect(find.text('Device 2'), findsOneWidget);
     expect(find.text('Summary 2'), findsOneWidget);


### PR DESCRIPTION
- Use master detail layout
- Show device flags as list instead of chips
- Move buttons to the top

![Screenshot from 2022-09-15 10-01-50](https://user-images.githubusercontent.com/113362648/190351681-ea658927-7c4e-4f9e-b623-19d4fd156ce8.png)
