### PR TITLE
Layout update

### DIFF
--- a/lib/firmware_model.dart
+++ b/lib/firmware_model.dart
@@ -19,7 +19,7 @@ class FirmwareModel extends SafeChangeNotifier {
 
   final FwupdService _service;
   final FwupdNotifier _monitor;
-  var _state = FirmwareState.empty;
+  var _state = const FirmwareState.loading();
 
   FirmwareState get state => _state;
 

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
@@ -57,7 +58,7 @@ class _FirmwarePageState extends State<FirmwarePage> {
                     onInstall: (release) => model.install(device, release),
                     hasUpgrade: state.hasUpgrade(device),
                   ),
-                  iconData: YaruIcons.computer,
+                  iconData: DeviceIcon.fromName(device.icon.firstOrNull),
                 ))
             .toList(),
         leftPaneWidth: 400,

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -1,10 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:yaru_colors/yaru_colors.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'firmware_model.dart';

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -41,7 +41,6 @@ class _FirmwarePageState extends State<FirmwarePage> {
   @override
   Widget build(BuildContext context) {
     final model = context.watch<FirmwareModel>();
-    final fwupd = context.watch<FwupdNotifier>();
     return model.state.map(
       data: (state) => YaruMasterDetailPage(
         pageItems: state.devices

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_colors/yaru_colors.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'firmware_model.dart';
 import 'fwupd_notifier.dart';
@@ -39,43 +41,29 @@ class _FirmwarePageState extends State<FirmwarePage> {
   Widget build(BuildContext context) {
     final model = context.watch<FirmwareModel>();
     final fwupd = context.watch<FwupdNotifier>();
-    return Scaffold(
-      backgroundColor: Theme.of(context).brightness == Brightness.light
-          ? YaruColors.warmGrey.shade200
-          : null,
-      appBar: AppProgressBar(
-        title: AppLocalizations.of(context).appTitle,
-        height: ProgressIndicatorTheme.of(context).linearMinHeight,
-        status: fwupd.status,
-        progress: fwupd.percentage / 100,
-        onRefresh: model.refresh,
+    return model.state.map(
+      data: (state) => YaruMasterDetailPage(
+        pageItems: state.devices
+            .map((device) => YaruPageItem(
+                  titleBuilder: (context) => DeviceHeader(
+                    device: device,
+                    hasUpgrade: state.hasUpgrade(device),
+                  ),
+                  builder: (context) => DeviceBody(
+                    device: device,
+                    canVerify: device.canVerify,
+                    onVerify: () => model.verify(device),
+                    releases: state.getReleases(device) ?? [],
+                    onInstall: (release) => model.install(device, release),
+                    hasUpgrade: state.hasUpgrade(device),
+                  ),
+                  iconData: YaruIcons.computer,
+                ))
+            .toList(),
+        leftPaneWidth: 400,
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
-        child: model.state.map(
-          data: (state) => DevicePanelList(
-            devices: state.devices,
-            headerBuilder: (context, device, isExpanded) => DeviceHeader(
-              device: device,
-              hasUpgrade: state.hasUpgrade(device),
-            ),
-            bodyBuilder: (context, device, child) => DeviceBody(
-              device: device,
-              canVerify: device.canVerify,
-              hasUpgrade: state.hasUpgrade(device),
-              releases: state.getReleases(device) ?? [],
-              onVerify: () => model.verify(device),
-              onInstall: (release) => model.install(device, release),
-            ),
-          ),
-          loading: (state) => const Center(child: CircularProgressIndicator()),
-          error: (state) => ErrorWidget(state.error),
-        ),
-      ),
-      bottomNavigationBar: StatusBar(
-        status: fwupd.status,
-        daemonVersion: fwupd.version,
-      ),
+      loading: (state) => const Center(child: CircularProgressIndicator()),
+      error: (state) => ErrorWidget(state.error),
     );
   }
 }

--- a/lib/src/widgets/device_header.dart
+++ b/lib/src/widgets/device_header.dart
@@ -1,9 +1,7 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
 
-import 'device_icon.dart';
 import 'small_chip.dart';
 
 class DeviceHeader extends StatelessWidget {

--- a/lib/src/widgets/device_header.dart
+++ b/lib/src/widgets/device_header.dart
@@ -24,7 +24,6 @@ class DeviceHeader extends StatelessWidget {
         ListTile(
           title: Text(device.name),
           subtitle: Text(device.summary ?? ''),
-          leading: DeviceIcon.fromName(device.icon.firstOrNull),
           contentPadding: const EdgeInsets.only(left: 24),
         ),
         if (hasUpgrade)

--- a/lib/src/widgets/device_icon.dart
+++ b/lib/src/widgets/device_icon.dart
@@ -44,12 +44,12 @@ const yaruIcons = <String, IconData>{
 
 // TODO: https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
 class DeviceIcon {
-  static Widget? fromName(String? name) {
+  static IconData fromName(String? name) {
     final icon = yaruIcons[name];
     if (icon == null && name != null) {
       debugPrint('Missing icon: $name');
-      return const SizedBox(width: 24, height: 24, child: Placeholder());
+      return YaruIcons.question;
     }
-    return Icon(icon ?? YaruIcons.computer);
+    return icon ?? YaruIcons.computer;
   }
 }

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -1,6 +1,7 @@
 export 'src/widgets/app_progress_bar.dart';
 export 'src/widgets/device_body.dart';
 export 'src/widgets/device_header.dart';
+export 'src/widgets/device_icon.dart';
 export 'src/widgets/device_panel_list.dart';
 export 'src/widgets/message_dialog.dart';
 export 'src/widgets/option_card.dart';

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -48,10 +48,10 @@ static void my_application_activate(GApplication* application) {
   }
 
   GdkGeometry geometry;
-  geometry.min_width = 600;
+  geometry.min_width = 800;
   geometry.min_height = 700;
   gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
-  gtk_window_set_default_size(window, 700, 850);
+  gtk_window_set_default_size(window, 1280, 720);
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(


### PR DESCRIPTION
First part of the layout update (part of a smaller breakdown of #46):
- replace Scaffold with YaruMasterDetailPage
- fix redundant icons
- ensure FirmwareModel starts in loading state