### PR TITLE
Update layout of device body

### DIFF
--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -3,7 +3,8 @@
   "close": "Close",
   "current": "Current",
   "downgrade": "Downgrade",
-  "guid": "GUID",
+  "flags": "Flags",
+  "guid": "GUIDs",
   "reinstall": "Reinstall",
   "showReleases": "Show Releases",
   "showUpdates": "Show Updates",
@@ -11,5 +12,6 @@
   "upgrade": "Upgrade",
   "vendor": "Vendor",
   "verifyFirmware": "Verify Firmware",
-  "version": "Version"
+  "currentVersion": "Current Version",
+  "minVersion": "Minimum Version"
 }

--- a/lib/src/widgets/device_body.dart
+++ b/lib/src/widgets/device_body.dart
@@ -1,8 +1,10 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
 
+import 'device_icon.dart';
 import 'release_dialog.dart';
 import 'small_chip.dart';
 
@@ -45,100 +47,145 @@ class DeviceBody extends StatelessWidget {
     return _buildPadding(Text(text));
   }
 
+  static Widget _buildIconRow(
+    BuildContext context,
+    String vendor,
+    String name,
+    String description,
+    IconData icon,
+  ) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          size: 64,
+        ),
+        const SizedBox(width: 16),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              vendor,
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            Text(
+              name,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            Text(
+              description,
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return Padding(
-      padding: const EdgeInsets.only(top: 4, left: 16, right: 16, bottom: 16),
+      padding: const EdgeInsets.all(16),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Table(
-                columnWidths: const {
-                  0: IntrinsicColumnWidth(),
-                  1: FixedColumnWidth(16),
-                  2: IntrinsicColumnWidth(),
-                },
-                children: [
-                  if (device.version != null)
-                    TableRow(children: [
-                      DeviceBody._buildHeader(context, l10n.version),
-                      const SizedBox.shrink(),
-                      DeviceBody._buildLabel(context, device.version!),
-                    ]),
-                  if (device.vendor != null)
-                    TableRow(children: [
-                      DeviceBody._buildHeader(context, l10n.vendor),
-                      const SizedBox.shrink(),
-                      DeviceBody._buildLabel(context, device.vendor!),
-                    ]),
-                  if (device.guid.isNotEmpty)
-                    TableRow(children: [
-                      DeviceBody._buildHeader(context, l10n.guid),
-                      const SizedBox.shrink(),
-                      DeviceBody._buildPadding(
-                          SelectableText(device.guid.first)),
-                    ]),
-                  if (device.guid.length > 1)
-                    for (final guid in device.guid.skip(1))
-                      TableRow(children: [
-                        DeviceBody._buildHeader(context, ''),
-                        const SizedBox.shrink(),
-                        DeviceBody._buildPadding(SelectableText(guid)),
-                      ]),
-                ],
+              DeviceBody._buildIconRow(
+                context,
+                device.vendor ?? '',
+                device.name,
+                device.summary ?? '',
+                DeviceIcon.fromName(device.icon.firstOrNull),
               ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    alignment: WrapAlignment.end,
-                    children: [
-                      for (final flag in device.flags)
-                        SmallChip(text: describeEnum(flag)),
-                    ],
-                  ),
+              if (canVerify || releases.isNotEmpty) const Spacer(),
+              if (canVerify || releases.isNotEmpty)
+                ButtonBar(
+                  children: [
+                    if (canVerify)
+                      OutlinedButton(
+                        onPressed: onVerify,
+                        child: Text(l10n.verifyFirmware),
+                      ),
+                    if (releases.isNotEmpty)
+                      hasUpgrade
+                          ? ElevatedButton(
+                              onPressed: () => showReleaseDialog(
+                                context,
+                                device: device,
+                                releases: releases,
+                                onInstall: onInstall,
+                              ),
+                              child: Text(l10n.showUpdates),
+                            )
+                          : OutlinedButton(
+                              onPressed: () => showReleaseDialog(
+                                context,
+                                device: device,
+                                releases: releases,
+                                onInstall: onInstall,
+                              ),
+                              child: Text(l10n.showReleases),
+                            ),
+                  ],
                 ),
-              ),
             ],
           ),
-          if (canVerify || releases.isNotEmpty) const SizedBox(height: 16),
-          if (canVerify || releases.isNotEmpty)
-            ButtonBar(
-              children: [
-                if (canVerify)
-                  OutlinedButton(
-                    onPressed: onVerify,
-                    child: Text(l10n.verifyFirmware),
-                  ),
-                if (releases.isNotEmpty)
-                  hasUpgrade
-                      ? ElevatedButton(
-                          onPressed: () => showReleaseDialog(
-                            context,
-                            device: device,
-                            releases: releases,
-                            onInstall: onInstall,
-                          ),
-                          child: Text(l10n.showUpdates),
-                        )
-                      : OutlinedButton(
-                          onPressed: () => showReleaseDialog(
-                            context,
-                            device: device,
-                            releases: releases,
-                            onInstall: onInstall,
-                          ),
-                          child: Text(l10n.showReleases),
-                        ),
-              ],
-            ),
+          const SizedBox(height: 32),
+          Table(
+            columnWidths: const {
+              0: IntrinsicColumnWidth(),
+              1: FixedColumnWidth(16),
+              2: IntrinsicColumnWidth(),
+            },
+            children: [
+              if (device.version != null)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.currentVersion),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildLabel(context, device.version!),
+                ]),
+              if (device.versionLowest != null)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.minVersion),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildLabel(context, device.versionLowest!),
+                ]),
+              if (device.vendor != null)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.vendor),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildLabel(context, device.vendor!),
+                ]),
+              if (device.guid.isNotEmpty)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.guid),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildPadding(SelectableText(device.guid.first)),
+                ]),
+              if (device.guid.length > 1)
+                for (final guid in device.guid.skip(1))
+                  TableRow(children: [
+                    DeviceBody._buildHeader(context, ''),
+                    const SizedBox.shrink(),
+                    DeviceBody._buildPadding(SelectableText(guid)),
+                  ]),
+              if (device.flags.isNotEmpty)
+                TableRow(children: [
+                  DeviceBody._buildHeader(context, l10n.flags),
+                  const SizedBox.shrink(),
+                  DeviceBody._buildPadding(
+                      Text(describeEnum(device.flags.first)))
+                ]),
+              if (device.flags.length > 1)
+                for (final flag in device.flags.skip(1))
+                  TableRow(children: [
+                    DeviceBody._buildHeader(context, ''),
+                    const SizedBox.shrink(),
+                    DeviceBody._buildPadding(Text(describeEnum(flag)))
+                  ]),
+            ],
+          ),
         ],
       ),
     );

--- a/lib/src/widgets/device_body.dart
+++ b/lib/src/widgets/device_body.dart
@@ -60,22 +60,24 @@ class DeviceBody extends StatelessWidget {
           size: 64,
         ),
         const SizedBox(width: 16),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              vendor,
-              style: Theme.of(context).textTheme.labelLarge,
-            ),
-            Text(
-              name,
-              style: Theme.of(context).textTheme.headlineSmall,
-            ),
-            Text(
-              description,
-              style: Theme.of(context).textTheme.labelMedium,
-            ),
-          ],
+        Flexible(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                vendor,
+                style: Theme.of(context).textTheme.labelLarge,
+              ),
+              Text(
+                name,
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              Text(
+                description,
+                style: Theme.of(context).textTheme.labelMedium,
+              ),
+            ],
+          ),
         ),
       ],
     );
@@ -89,15 +91,17 @@ class DeviceBody extends StatelessWidget {
       child: Column(
         children: [
           Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              DeviceBody._buildIconRow(
-                context,
-                device.vendor ?? '',
-                device.name,
-                device.summary ?? '',
-                DeviceIcon.fromName(device.icon.firstOrNull),
+              Flexible(
+                child: DeviceBody._buildIconRow(
+                  context,
+                  device.vendor ?? '',
+                  device.name,
+                  device.summary ?? '',
+                  DeviceIcon.fromName(device.icon.firstOrNull),
+                ),
               ),
-              if (canVerify || releases.isNotEmpty) const Spacer(),
               if (canVerify || releases.isNotEmpty)
                 ButtonBar(
                   children: [

--- a/lib/src/widgets/device_body.dart
+++ b/lib/src/widgets/device_body.dart
@@ -6,7 +6,6 @@ import 'package:fwupd/fwupd.dart';
 
 import 'device_icon.dart';
 import 'release_dialog.dart';
-import 'small_chip.dart';
 
 class DeviceBody extends StatelessWidget {
   const DeviceBody({

--- a/lib/src/widgets/device_body.dart
+++ b/lib/src/widgets/device_body.dart
@@ -54,6 +54,7 @@ class DeviceBody extends StatelessWidget {
     IconData icon,
   ) {
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
         Icon(
           icon,
@@ -89,21 +90,22 @@ class DeviceBody extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          Wrap(
+            alignment: WrapAlignment.spaceBetween,
+            runSpacing: 16.0,
             children: [
-              Flexible(
-                child: DeviceBody._buildIconRow(
-                  context,
-                  device.vendor ?? '',
-                  device.name,
-                  device.summary ?? '',
-                  DeviceIcon.fromName(device.icon.firstOrNull),
-                ),
+              DeviceBody._buildIconRow(
+                context,
+                device.vendor ?? '',
+                device.name,
+                device.summary ?? '',
+                DeviceIcon.fromName(device.icon.firstOrNull),
               ),
               if (canVerify || releases.isNotEmpty)
                 ButtonBar(
+                  mainAxisSize: MainAxisSize.min,
                   children: [
                     if (canVerify)
                       OutlinedButton(
@@ -137,9 +139,9 @@ class DeviceBody extends StatelessWidget {
           const SizedBox(height: 32),
           Table(
             columnWidths: const {
-              0: IntrinsicColumnWidth(),
+              0: FlexColumnWidth(),
               1: FixedColumnWidth(16),
-              2: IntrinsicColumnWidth(),
+              2: FlexColumnWidth(2.0),
             },
             children: [
               if (device.version != null)

--- a/test/firmare_page_test.dart
+++ b/test/firmare_page_test.dart
@@ -63,8 +63,9 @@ void main() {
     await tester
         .pumpApp((_) => buildPage(model: model, notifier: mockNotifier()));
 
-    expect(find.text('Device 1'), findsOneWidget);
-    expect(find.text('Summary 1'), findsOneWidget);
+    // First device appears twice in master detail layout
+    expect(find.text('Device 1'), findsNWidgets(2));
+    expect(find.text('Summary 1'), findsNWidgets(2));
 
     expect(find.text('Device 2'), findsOneWidget);
     expect(find.text('Summary 2'), findsOneWidget);


### PR DESCRIPTION
Second part of the layout update (part of a smaller breakdown of #46):
- Show device flags as list instead of chips
- Move buttons to the top