### PR TITLE
Upgrade Yaru

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,8 +16,8 @@ Future<void> main() async {
   runApp(YaruTheme(
     builder: (context, yaru, child) => MaterialApp(
       debugShowCheckedModeBanner: false,
-      theme: yaru.variant?.theme ?? yaruLight,
-      darkTheme: yaru.variant?.darkTheme ?? yaruDark,
+      theme: yaru.theme,
+      darkTheme: yaru.darkTheme,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   collection: ^1.15.0
@@ -26,10 +26,10 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_logger
   ubuntu_service: ^0.1.0
-  yaru: ^0.3.3
+  yaru: ^0.4.1
   yaru_colors: ^0.1.0
   yaru_icons: ^0.2.1
-  yaru_widgets: ^1.0.0
+  yaru_widgets: ^1.1.3
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
YaruTheme API has been simplified a bit, and YaruMasterDetailPage has gained page transitions.

https://user-images.githubusercontent.com/140617/191014544-87a6fd23-6fdc-415e-8c32-b5e4b1d6706c.mp4

NOTE: Yaru 0.4 requires Flutter 3.3.