### PR TITLE
Refactor state mgmt

### DIFF
--- a/lib/device_model.dart
+++ b/lib/device_model.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import 'package:fwupd/fwupd.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+import 'device_state.dart';
+import 'fwupd_service.dart';
+import 'fwupd_x.dart';
+
+final log = Logger('device_model');
+
+class DeviceModel extends SafeChangeNotifier {
+  DeviceModel(this._service, this._device);
+
+  final FwupdService _service;
+  final FwupdDevice _device;
+  var _state = const DeviceState.loading();
+
+  @protected
+  set state(DeviceState value) {
+    log.debug(value);
+    if (_state == value) return;
+    _state = value;
+    notifyListeners();
+  }
+
+  FwupdDevice get device => _device;
+
+  Future<void> refresh() async {
+    await _updateState();
+    notifyListeners();
+  }
+
+  DeviceState get state => _state;
+
+  Future<void> _updateState() async => state = await _fetchState();
+  Future<void> init() {
+    log.debug('init');
+    return _updateState();
+    // return _service.init().then((_) => _updateState());
+  }
+
+  Future<void> install(FwupdRelease release) async {
+    try {
+      await _service.install(_device, release);
+      // TODO: FwupdException
+    } on Exception catch (error, stackTrace) {
+      log.error('installation failed $error');
+      state = DeviceState.error(
+        error: error,
+        stackTrace: stackTrace,
+        previous: state,
+      );
+    }
+  }
+
+  Future<void> verify() => _service.verify(_device);
+
+  Future<DeviceState> _fetchState() async {
+    try {
+      return DeviceState.data(
+        device: _device,
+        releases: await _fetchReleases(),
+      );
+    } on FwupdException catch (e) {
+      return DeviceState.error(error: e);
+    }
+  }
+
+  Future<List<FwupdRelease>> _fetchReleases() {
+    log.debug('fetchReleases ${_device.name}');
+    return _service.getReleases(_device.id).catchError(
+          (e) => <FwupdRelease>[],
+          test: (e) =>
+              e is FwupdNothingToDoException || e is FwupdNotSupportedException,
+        );
+  }
+}

--- a/lib/device_state.dart
+++ b/lib/device_state.dart
@@ -1,0 +1,41 @@
+import 'package:collection/collection.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:fwupd/fwupd.dart';
+
+import 'fwupd_x.dart';
+
+part 'device_state.freezed.dart';
+
+@freezed
+class DeviceState with _$DeviceState {
+  const DeviceState._();
+
+  const factory DeviceState.data({
+    required FwupdDevice device,
+    required List<FwupdRelease> releases,
+  }) = DeviceDataState;
+
+  const factory DeviceState.loading({
+    DeviceState? previous,
+  }) = DeviceLoadingState;
+
+  const factory DeviceState.error({
+    required Object error,
+    StackTrace? stackTrace,
+    DeviceState? previous,
+  }) = DeviceErrorState;
+
+  // static const empty = DeviceState.data(releases: []);
+
+  List<FwupdRelease>? getReleases() {
+    return when(
+      data: (device, releases) => releases,
+      loading: (previous) => previous?.getReleases(),
+      error: (error, stackTrace, previous) => previous?.getReleases(),
+    );
+  }
+
+  bool hasUpgrade() {
+    return getReleases()?.firstWhereOrNull((r) => r.isUpgrade) != null;
+  }
+}

--- a/lib/device_state.freezed.dart
+++ b/lib/device_state.freezed.dart
@@ -1,0 +1,605 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'device_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$DeviceState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(FwupdDevice device, List<FwupdRelease> releases)
+        data,
+    required TResult Function(DeviceState? previous) loading,
+    required TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)
+        error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(FwupdDevice device, List<FwupdRelease> releases)? data,
+    TResult Function(DeviceState? previous)? loading,
+    TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)?
+        error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(FwupdDevice device, List<FwupdRelease> releases)? data,
+    TResult Function(DeviceState? previous)? loading,
+    TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)?
+        error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(DeviceDataState value) data,
+    required TResult Function(DeviceLoadingState value) loading,
+    required TResult Function(DeviceErrorState value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(DeviceDataState value)? data,
+    TResult Function(DeviceLoadingState value)? loading,
+    TResult Function(DeviceErrorState value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(DeviceDataState value)? data,
+    TResult Function(DeviceLoadingState value)? loading,
+    TResult Function(DeviceErrorState value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DeviceStateCopyWith<$Res> {
+  factory $DeviceStateCopyWith(
+          DeviceState value, $Res Function(DeviceState) then) =
+      _$DeviceStateCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$DeviceStateCopyWithImpl<$Res> implements $DeviceStateCopyWith<$Res> {
+  _$DeviceStateCopyWithImpl(this._value, this._then);
+
+  final DeviceState _value;
+  // ignore: unused_field
+  final $Res Function(DeviceState) _then;
+}
+
+/// @nodoc
+abstract class _$$DeviceDataStateCopyWith<$Res> {
+  factory _$$DeviceDataStateCopyWith(
+          _$DeviceDataState value, $Res Function(_$DeviceDataState) then) =
+      __$$DeviceDataStateCopyWithImpl<$Res>;
+  $Res call({FwupdDevice device, List<FwupdRelease> releases});
+}
+
+/// @nodoc
+class __$$DeviceDataStateCopyWithImpl<$Res>
+    extends _$DeviceStateCopyWithImpl<$Res>
+    implements _$$DeviceDataStateCopyWith<$Res> {
+  __$$DeviceDataStateCopyWithImpl(
+      _$DeviceDataState _value, $Res Function(_$DeviceDataState) _then)
+      : super(_value, (v) => _then(v as _$DeviceDataState));
+
+  @override
+  _$DeviceDataState get _value => super._value as _$DeviceDataState;
+
+  @override
+  $Res call({
+    Object? device = freezed,
+    Object? releases = freezed,
+  }) {
+    return _then(_$DeviceDataState(
+      device: device == freezed
+          ? _value.device
+          : device // ignore: cast_nullable_to_non_nullable
+              as FwupdDevice,
+      releases: releases == freezed
+          ? _value._releases
+          : releases // ignore: cast_nullable_to_non_nullable
+              as List<FwupdRelease>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$DeviceDataState extends DeviceDataState {
+  const _$DeviceDataState(
+      {required this.device, required final List<FwupdRelease> releases})
+      : _releases = releases,
+        super._();
+
+  @override
+  final FwupdDevice device;
+  final List<FwupdRelease> _releases;
+  @override
+  List<FwupdRelease> get releases {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_releases);
+  }
+
+  @override
+  String toString() {
+    return 'DeviceState.data(device: $device, releases: $releases)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DeviceDataState &&
+            const DeepCollectionEquality().equals(other.device, device) &&
+            const DeepCollectionEquality().equals(other._releases, _releases));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(device),
+      const DeepCollectionEquality().hash(_releases));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$DeviceDataStateCopyWith<_$DeviceDataState> get copyWith =>
+      __$$DeviceDataStateCopyWithImpl<_$DeviceDataState>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(FwupdDevice device, List<FwupdRelease> releases)
+        data,
+    required TResult Function(DeviceState? previous) loading,
+    required TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)
+        error,
+  }) {
+    return data(device, releases);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(FwupdDevice device, List<FwupdRelease> releases)? data,
+    TResult Function(DeviceState? previous)? loading,
+    TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)?
+        error,
+  }) {
+    return data?.call(device, releases);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(FwupdDevice device, List<FwupdRelease> releases)? data,
+    TResult Function(DeviceState? previous)? loading,
+    TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)?
+        error,
+    required TResult orElse(),
+  }) {
+    if (data != null) {
+      return data(device, releases);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(DeviceDataState value) data,
+    required TResult Function(DeviceLoadingState value) loading,
+    required TResult Function(DeviceErrorState value) error,
+  }) {
+    return data(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(DeviceDataState value)? data,
+    TResult Function(DeviceLoadingState value)? loading,
+    TResult Function(DeviceErrorState value)? error,
+  }) {
+    return data?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(DeviceDataState value)? data,
+    TResult Function(DeviceLoadingState value)? loading,
+    TResult Function(DeviceErrorState value)? error,
+    required TResult orElse(),
+  }) {
+    if (data != null) {
+      return data(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class DeviceDataState extends DeviceState {
+  const factory DeviceDataState(
+      {required final FwupdDevice device,
+      required final List<FwupdRelease> releases}) = _$DeviceDataState;
+  const DeviceDataState._() : super._();
+
+  FwupdDevice get device;
+  List<FwupdRelease> get releases;
+  @JsonKey(ignore: true)
+  _$$DeviceDataStateCopyWith<_$DeviceDataState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$DeviceLoadingStateCopyWith<$Res> {
+  factory _$$DeviceLoadingStateCopyWith(_$DeviceLoadingState value,
+          $Res Function(_$DeviceLoadingState) then) =
+      __$$DeviceLoadingStateCopyWithImpl<$Res>;
+  $Res call({DeviceState? previous});
+
+  $DeviceStateCopyWith<$Res>? get previous;
+}
+
+/// @nodoc
+class __$$DeviceLoadingStateCopyWithImpl<$Res>
+    extends _$DeviceStateCopyWithImpl<$Res>
+    implements _$$DeviceLoadingStateCopyWith<$Res> {
+  __$$DeviceLoadingStateCopyWithImpl(
+      _$DeviceLoadingState _value, $Res Function(_$DeviceLoadingState) _then)
+      : super(_value, (v) => _then(v as _$DeviceLoadingState));
+
+  @override
+  _$DeviceLoadingState get _value => super._value as _$DeviceLoadingState;
+
+  @override
+  $Res call({
+    Object? previous = freezed,
+  }) {
+    return _then(_$DeviceLoadingState(
+      previous: previous == freezed
+          ? _value.previous
+          : previous // ignore: cast_nullable_to_non_nullable
+              as DeviceState?,
+    ));
+  }
+
+  @override
+  $DeviceStateCopyWith<$Res>? get previous {
+    if (_value.previous == null) {
+      return null;
+    }
+
+    return $DeviceStateCopyWith<$Res>(_value.previous!, (value) {
+      return _then(_value.copyWith(previous: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$DeviceLoadingState extends DeviceLoadingState {
+  const _$DeviceLoadingState({this.previous}) : super._();
+
+  @override
+  final DeviceState? previous;
+
+  @override
+  String toString() {
+    return 'DeviceState.loading(previous: $previous)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DeviceLoadingState &&
+            const DeepCollectionEquality().equals(other.previous, previous));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(previous));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$DeviceLoadingStateCopyWith<_$DeviceLoadingState> get copyWith =>
+      __$$DeviceLoadingStateCopyWithImpl<_$DeviceLoadingState>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(FwupdDevice device, List<FwupdRelease> releases)
+        data,
+    required TResult Function(DeviceState? previous) loading,
+    required TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)
+        error,
+  }) {
+    return loading(previous);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(FwupdDevice device, List<FwupdRelease> releases)? data,
+    TResult Function(DeviceState? previous)? loading,
+    TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)?
+        error,
+  }) {
+    return loading?.call(previous);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(FwupdDevice device, List<FwupdRelease> releases)? data,
+    TResult Function(DeviceState? previous)? loading,
+    TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)?
+        error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(previous);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(DeviceDataState value) data,
+    required TResult Function(DeviceLoadingState value) loading,
+    required TResult Function(DeviceErrorState value) error,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(DeviceDataState value)? data,
+    TResult Function(DeviceLoadingState value)? loading,
+    TResult Function(DeviceErrorState value)? error,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(DeviceDataState value)? data,
+    TResult Function(DeviceLoadingState value)? loading,
+    TResult Function(DeviceErrorState value)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class DeviceLoadingState extends DeviceState {
+  const factory DeviceLoadingState({final DeviceState? previous}) =
+      _$DeviceLoadingState;
+  const DeviceLoadingState._() : super._();
+
+  DeviceState? get previous;
+  @JsonKey(ignore: true)
+  _$$DeviceLoadingStateCopyWith<_$DeviceLoadingState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$DeviceErrorStateCopyWith<$Res> {
+  factory _$$DeviceErrorStateCopyWith(
+          _$DeviceErrorState value, $Res Function(_$DeviceErrorState) then) =
+      __$$DeviceErrorStateCopyWithImpl<$Res>;
+  $Res call({Object error, StackTrace? stackTrace, DeviceState? previous});
+
+  $DeviceStateCopyWith<$Res>? get previous;
+}
+
+/// @nodoc
+class __$$DeviceErrorStateCopyWithImpl<$Res>
+    extends _$DeviceStateCopyWithImpl<$Res>
+    implements _$$DeviceErrorStateCopyWith<$Res> {
+  __$$DeviceErrorStateCopyWithImpl(
+      _$DeviceErrorState _value, $Res Function(_$DeviceErrorState) _then)
+      : super(_value, (v) => _then(v as _$DeviceErrorState));
+
+  @override
+  _$DeviceErrorState get _value => super._value as _$DeviceErrorState;
+
+  @override
+  $Res call({
+    Object? error = freezed,
+    Object? stackTrace = freezed,
+    Object? previous = freezed,
+  }) {
+    return _then(_$DeviceErrorState(
+      error: error == freezed
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as Object,
+      stackTrace: stackTrace == freezed
+          ? _value.stackTrace
+          : stackTrace // ignore: cast_nullable_to_non_nullable
+              as StackTrace?,
+      previous: previous == freezed
+          ? _value.previous
+          : previous // ignore: cast_nullable_to_non_nullable
+              as DeviceState?,
+    ));
+  }
+
+  @override
+  $DeviceStateCopyWith<$Res>? get previous {
+    if (_value.previous == null) {
+      return null;
+    }
+
+    return $DeviceStateCopyWith<$Res>(_value.previous!, (value) {
+      return _then(_value.copyWith(previous: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$DeviceErrorState extends DeviceErrorState {
+  const _$DeviceErrorState(
+      {required this.error, this.stackTrace, this.previous})
+      : super._();
+
+  @override
+  final Object error;
+  @override
+  final StackTrace? stackTrace;
+  @override
+  final DeviceState? previous;
+
+  @override
+  String toString() {
+    return 'DeviceState.error(error: $error, stackTrace: $stackTrace, previous: $previous)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DeviceErrorState &&
+            const DeepCollectionEquality().equals(other.error, error) &&
+            const DeepCollectionEquality()
+                .equals(other.stackTrace, stackTrace) &&
+            const DeepCollectionEquality().equals(other.previous, previous));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(error),
+      const DeepCollectionEquality().hash(stackTrace),
+      const DeepCollectionEquality().hash(previous));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$DeviceErrorStateCopyWith<_$DeviceErrorState> get copyWith =>
+      __$$DeviceErrorStateCopyWithImpl<_$DeviceErrorState>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(FwupdDevice device, List<FwupdRelease> releases)
+        data,
+    required TResult Function(DeviceState? previous) loading,
+    required TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)
+        error,
+  }) {
+    return error(this.error, stackTrace, previous);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(FwupdDevice device, List<FwupdRelease> releases)? data,
+    TResult Function(DeviceState? previous)? loading,
+    TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)?
+        error,
+  }) {
+    return error?.call(this.error, stackTrace, previous);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(FwupdDevice device, List<FwupdRelease> releases)? data,
+    TResult Function(DeviceState? previous)? loading,
+    TResult Function(
+            Object error, StackTrace? stackTrace, DeviceState? previous)?
+        error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error, stackTrace, previous);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(DeviceDataState value) data,
+    required TResult Function(DeviceLoadingState value) loading,
+    required TResult Function(DeviceErrorState value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(DeviceDataState value)? data,
+    TResult Function(DeviceLoadingState value)? loading,
+    TResult Function(DeviceErrorState value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(DeviceDataState value)? data,
+    TResult Function(DeviceLoadingState value)? loading,
+    TResult Function(DeviceErrorState value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class DeviceErrorState extends DeviceState {
+  const factory DeviceErrorState(
+      {required final Object error,
+      final StackTrace? stackTrace,
+      final DeviceState? previous}) = _$DeviceErrorState;
+  const DeviceErrorState._() : super._();
+
+  Object get error;
+  StackTrace? get stackTrace;
+  DeviceState? get previous;
+  @JsonKey(ignore: true)
+  _$$DeviceErrorStateCopyWith<_$DeviceErrorState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/firmware_body_page.dart
+++ b/lib/firmware_body_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:fwupd/fwupd.dart';
+import 'package:provider/provider.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+import 'device_model.dart';
+import 'fwupd_service.dart';
+import 'fwupd_x.dart';
+import 'widgets.dart';
+
+class FirmwareBodyPage extends StatefulWidget {
+  const FirmwareBodyPage({
+    super.key,
+    required this.device,
+  });
+
+  final FwupdDevice device;
+
+  static Widget create(BuildContext context, {required FwupdDevice device}) {
+    final service = getService<FwupdService>();
+    final key = GlobalKey();
+    return ChangeNotifierProvider(
+      key: key,
+      create: (_) => DeviceModel(service, device),
+      child: FirmwareBodyPage(device: device),
+    );
+  }
+
+  @override
+  State<FirmwareBodyPage> createState() => _FirmwareBodyPageState();
+}
+
+class _FirmwareBodyPageState extends State<FirmwareBodyPage> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<DeviceModel>().init();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final model = context.watch<DeviceModel>();
+    return model.state.map(
+      data: (state) => DeviceBody(
+        device: widget.device,
+        canVerify: widget.device.canVerify,
+        onVerify: model.verify,
+        releases: state.releases,
+        onInstall: model.install,
+        hasUpgrade: state.hasUpgrade(),
+      ),
+      loading: (state) => const Center(child: YaruCircularProgressIndicator()),
+      error: (state) => ErrorWidget(state.error),
+    );
+  }
+}

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -4,10 +4,10 @@ import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import 'firmware_body_page.dart';
 import 'firmware_model.dart';
 import 'fwupd_notifier.dart';
 import 'fwupd_service.dart';
-import 'fwupd_x.dart';
 import 'widgets.dart';
 
 class FirmwarePage extends StatefulWidget {
@@ -46,13 +46,9 @@ class _FirmwarePageState extends State<FirmwarePage> {
                     device: device,
                     hasUpgrade: state.hasUpgrade(device),
                   ),
-                  builder: (context) => DeviceBody(
+                  builder: (context) => FirmwareBodyPage.create(
+                    context,
                     device: device,
-                    canVerify: device.canVerify,
-                    onVerify: () => model.verify(device),
-                    releases: state.getReleases(device) ?? [],
-                    onInstall: (release) => model.install(device, release),
-                    hasUpgrade: state.hasUpgrade(device),
                   ),
                   iconData: DeviceIcon.fromName(device.icon.firstOrNull),
                 ))

--- a/test/device_model_test.dart
+++ b/test/device_model_test.dart
@@ -1,0 +1,96 @@
+import 'package:firmware_updater/device_model.dart';
+import 'package:firmware_updater/device_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fwupd/fwupd.dart';
+import 'package:mockito/mockito.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  test('initializes service', () async {
+    final service = mockService();
+    final device = testDevice(id: '');
+
+    final model = DeviceModel(service, device);
+    await model.init();
+
+    verify(service.init()).called(1);
+  });
+
+  test('fetches releases', () async {
+    final devices = [
+      testDevice(id: 'a'),
+      testDevice(id: 'b'),
+      testDevice(id: 'c'),
+    ];
+
+    final releases = {
+      'a': [
+        FwupdRelease(version: '1', name: ''),
+        FwupdRelease(version: '2', name: ''),
+      ],
+      'c': [
+        FwupdRelease(version: '3', name: ''),
+      ]
+    };
+
+    final service = mockService(devices: devices, releases: releases);
+    final device = devices.first;
+    final deviceReleases = releases['a']!;
+
+    final model = DeviceModel(service, device);
+    await model.init();
+
+    expect(
+        model.state,
+        DeviceState.data(
+          device: device,
+          releases: deviceReleases,
+        ));
+  });
+
+  test('install release', () async {
+    final device = testDevice(id: '');
+    final release = FwupdRelease(name: '');
+
+    final service = mockService();
+
+    final model = DeviceModel(service, device);
+    await model.install(release);
+    verify(service.install(device, release)).called(1);
+  });
+
+  test('installation failure', () async {
+    final device = testDevice(id: '');
+    final release = FwupdRelease(name: '');
+
+    final service = mockService();
+    when(service.install(device, release))
+        .thenThrow(const FwupdInvalidFileException());
+
+    final model = DeviceModel(service, device);
+    await model.install(release);
+    expect(model.state, isA<DeviceErrorState>());
+  });
+
+  test('nothing to do', () async {
+    final device = testDevice(id: '');
+
+    final service = mockService(devices: [device]);
+    when(service.getReleases(any)).thenThrow(const FwupdNothingToDoException());
+
+    final model = DeviceModel(service, device);
+    await model.init();
+    expect(model.state, isA<DeviceState>());
+  });
+
+  test('verify', () async {
+    final device = testDevice(id: '');
+
+    final service = mockService();
+
+    final model = DeviceModel(service, device);
+    await model.verify();
+    verify(service.verify(device)).called(1);
+  });
+}


### PR DESCRIPTION
WIP.
* Extract list of releases and device functionality (install, verify..) from `FirmwareModel` and create a new `DeviceModel` (Goal: keep only list of devices in `FirmwareModel`, move all logic regarding releases to `DeviceModel`)
* Add `FirmwareBodyPage`, which renders a specific `DeviceModel` (Goal: disentangle lists of devices and releases to simplify  nested navigation in new design)