### PR TITLE
Device release page

### DIFF
--- a/lib/device_model.dart
+++ b/lib/device_model.dart
@@ -1,0 +1,27 @@
+import 'package:fwupd/fwupd.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
+
+import 'firmware_model.dart';
+
+class DeviceModel extends SafeChangeNotifier {
+  DeviceModel(this._firmwareModel, this._device)
+      : _releases = _firmwareModel.state.getReleases(_device);
+  final FirmwareModel _firmwareModel;
+  final FwupdDevice _device;
+  final List<FwupdRelease>? _releases;
+
+  FwupdRelease? _selectedRelease;
+  FwupdRelease? get selectedRelease => _selectedRelease;
+  set selectedRelease(FwupdRelease? release) {
+    _selectedRelease = release;
+    notifyListeners();
+  }
+
+  FwupdDevice get device => _device;
+  List<FwupdRelease>? get releases => _releases;
+
+  Future<void> verify() => _firmwareModel.verify(_device);
+  Future<void> install(FwupdRelease release) =>
+      _firmwareModel.install(_device, release);
+  bool hasUpgrade() => _firmwareModel.state.hasUpgrade(_device);
+}

--- a/lib/firmware_body_page.dart
+++ b/lib/firmware_body_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:fwupd/fwupd.dart';
+import 'package:provider/provider.dart';
+
+import 'device_model.dart';
+import 'firmware_model.dart';
+import 'fwupd_x.dart';
+import 'src/widgets/device_body.dart';
+import 'src/widgets/release_dialog.dart';
+
+class FirmwareBodyPage extends StatefulWidget {
+  const FirmwareBodyPage({
+    super.key,
+  });
+
+  static Widget create(
+    BuildContext context, {
+    required FwupdDevice device,
+  }) {
+    final firmwareModel = context.read<FirmwareModel>();
+    return ChangeNotifierProvider<DeviceModel>(
+      create: (_) => DeviceModel(firmwareModel, device),
+      child: const FirmwareBodyPage(),
+    );
+  }
+
+  @override
+  State<FirmwareBodyPage> createState() => _FirmwareBodyPageState();
+}
+
+class _FirmwareBodyPageState extends State<FirmwareBodyPage> {
+  @override
+  Widget build(BuildContext context) {
+    final deviceModel = context.watch<DeviceModel>();
+    return Navigator(
+      pages: [
+        MaterialPage(
+          child: DeviceBody(
+            device: deviceModel.device,
+            canVerify: deviceModel.device.canVerify,
+            onVerify: deviceModel.verify,
+            releases: deviceModel.releases ?? [],
+            onInstall: deviceModel.install,
+            hasUpgrade: deviceModel.hasUpgrade(),
+          ),
+        ),
+        if (deviceModel.selectedRelease != null)
+          MaterialPage(
+            child: ReleaseDialog(
+              device: deviceModel.device,
+              releases: deviceModel.releases ?? [],
+              onInstall: deviceModel.install,
+            ),
+          )
+      ],
+      onPopPage: (route, result) => route.didPop(result),
+    );
+  }
+}

--- a/lib/firmware_body_page.dart
+++ b/lib/firmware_body_page.dart
@@ -8,7 +8,7 @@ import 'fwupd_x.dart';
 import 'src/widgets/device_body.dart';
 import 'src/widgets/release_dialog.dart';
 
-class FirmwareBodyPage extends StatefulWidget {
+class FirmwareBodyPage extends StatelessWidget {
   const FirmwareBodyPage({
     super.key,
   });
@@ -24,11 +24,6 @@ class FirmwareBodyPage extends StatefulWidget {
     );
   }
 
-  @override
-  State<FirmwareBodyPage> createState() => _FirmwareBodyPageState();
-}
-
-class _FirmwareBodyPageState extends State<FirmwareBodyPage> {
   @override
   Widget build(BuildContext context) {
     final deviceModel = context.watch<DeviceModel>();

--- a/lib/firmware_page.dart
+++ b/lib/firmware_page.dart
@@ -4,10 +4,10 @@ import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import 'firmware_body_page.dart';
 import 'firmware_model.dart';
 import 'fwupd_notifier.dart';
 import 'fwupd_service.dart';
-import 'fwupd_x.dart';
 import 'widgets.dart';
 
 class FirmwarePage extends StatefulWidget {
@@ -46,13 +46,9 @@ class _FirmwarePageState extends State<FirmwarePage> {
                     device: device,
                     hasUpgrade: state.hasUpgrade(device),
                   ),
-                  builder: (context) => DeviceBody(
+                  builder: (context) => FirmwareBodyPage.create(
+                    context,
                     device: device,
-                    canVerify: device.canVerify,
-                    onVerify: () => model.verify(device),
-                    releases: state.getReleases(device) ?? [],
-                    onInstall: (release) => model.install(device, release),
-                    hasUpgrade: state.hasUpgrade(device),
                   ),
                   iconData: DeviceIcon.fromName(device.icon.firstOrNull),
                 ))

--- a/lib/src/widgets/device_body.dart
+++ b/lib/src/widgets/device_body.dart
@@ -2,10 +2,11 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
+import 'package:provider/provider.dart';
 
+import '../../device_model.dart';
 import '../../fwupd_l10n.dart';
 import 'device_icon.dart';
-import 'release_dialog.dart';
 
 class DeviceBody extends StatelessWidget {
   const DeviceBody({
@@ -118,21 +119,15 @@ class DeviceBody extends StatelessWidget {
                     if (releases.isNotEmpty)
                       hasUpgrade
                           ? ElevatedButton(
-                              onPressed: () => showReleaseDialog(
-                                context,
-                                device: device,
-                                releases: releases,
-                                onInstall: onInstall,
-                              ),
+                              onPressed: () => context
+                                  .read<DeviceModel>()
+                                  .selectedRelease = releases.first,
                               child: Text(l10n.showUpdates),
                             )
                           : OutlinedButton(
-                              onPressed: () => showReleaseDialog(
-                                context,
-                                device: device,
-                                releases: releases,
-                                onInstall: onInstall,
-                              ),
+                              onPressed: () => context
+                                  .read<DeviceModel>()
+                                  .selectedRelease = releases.first,
                               child: Text(l10n.showReleases),
                             ),
                   ],

--- a/test/device_model_test.dart
+++ b/test/device_model_test.dart
@@ -26,7 +26,7 @@ void main() {
   });
 
   test('install release', () async {
-    final device = testDevice(id: '');
+    final device = testDevice(id: 'a');
     final release = FwupdRelease(name: '');
 
     final service = mockService();
@@ -38,7 +38,7 @@ void main() {
   });
 
   test('verify', () async {
-    final device = testDevice(id: '');
+    final device = testDevice(id: 'a');
 
     final service = mockService();
 

--- a/test/device_model_test.dart
+++ b/test/device_model_test.dart
@@ -1,0 +1,50 @@
+import 'package:firmware_updater/device_model.dart';
+import 'package:firmware_updater/firmware_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fwupd/fwupd.dart';
+import 'package:mockito/mockito.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  test('fetches releases', () async {
+    final device = testDevice(id: 'a');
+
+    final releases = [
+      FwupdRelease(version: '1', name: ''),
+      FwupdRelease(version: '2', name: ''),
+    ];
+
+    final service = mockService(devices: [device], releases: {'a': releases});
+
+    final firmwareModel = FirmwareModel(service);
+    await firmwareModel.init();
+
+    final deviceModel = DeviceModel(firmwareModel, device);
+
+    expect(deviceModel.releases, releases);
+  });
+
+  test('install release', () async {
+    final device = testDevice(id: '');
+    final release = FwupdRelease(name: '');
+
+    final service = mockService();
+
+    final firmwareModel = FirmwareModel(service);
+    final deviceModel = DeviceModel(firmwareModel, device);
+    await deviceModel.install(release);
+    verify(service.install(device, release)).called(1);
+  });
+
+  test('verify', () async {
+    final device = testDevice(id: '');
+
+    final service = mockService();
+
+    final firmwareModel = FirmwareModel(service);
+    final deviceModel = DeviceModel(firmwareModel, device);
+    await deviceModel.verify();
+    verify(service.verify(device)).called(1);
+  });
+}


### PR DESCRIPTION
Show the release dialog as a page in the new layout. Design updates will follow.

* add `DeviceBodyPage` - renders the right pane in the master detail layout for each device
* add `DeviceModel` - view model for `DeviceBodyPage`
  - provides `install()`, `verify()` for the device by calling the respective methods of the `FirmwareModel`
  - keeps track of the currently selected release, `DeviceBodyPage` will respond accordingly 