### PR TITLE
Improve dialogs

### DIFF
--- a/integration_test/firmware_updater_test.dart
+++ b/integration_test/firmware_updater_test.dart
@@ -43,7 +43,7 @@ void main() {
       await tester.pumpAndTapButton(tester.lang.upgrade);
       await tester.pumpAndSettle();
 
-      await tester.pumpAndTapButton(tester.lang.ok);
+      await tester.pumpAndTapDialogButton(tester.lang.upgrade);
       await client.testInstallation(webcam, upgrade);
     });
 
@@ -75,7 +75,7 @@ void main() {
       await tester.pumpAndTapButton(tester.lang.reinstall);
       await tester.pumpAndSettle();
 
-      await tester.pumpAndTapButton(tester.lang.ok);
+      await tester.pumpAndTapDialogButton(tester.lang.reinstall);
       await client.testInstallation(webcam, reinstall);
     });
 
@@ -104,7 +104,7 @@ void main() {
       await tester.pumpAndTapButton(tester.lang.downgrade);
       await tester.pumpAndSettle();
 
-      await tester.pumpAndTapButton(tester.lang.ok);
+      await tester.pumpAndTapDialogButton(tester.lang.downgrade);
       await client.testInstallation(webcam, downgrade);
     });
   });
@@ -177,13 +177,25 @@ extension IntegrationTester on WidgetTester {
     return tap(header);
   }
 
-  Future<void> pumpAndTapButton(String text) async {
+  Future<void> pumpAndTapButton(String text) {
+    return _pumpAndTapButtonOfFinder(find.text(text));
+  }
+
+  Future<void> pumpAndTapDialogButton(String text) {
+    return _pumpAndTapButtonOfFinder(find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.text(text),
+    ));
+  }
+
+  Future<void> _pumpAndTapButtonOfFinder(Finder finder) async {
     final button = find.ancestor(
-      of: find.text(text),
+      of: finder,
       matching: find.byWidgetPredicate((widget) => widget is ButtonStyleButton),
     );
     if (button.evaluate().length > 1) {
-      debugPrint('WARNING: Multiple "$text" buttons. Assuming the first.');
+      debugPrint(
+          'WARNING: Found multiple buttons in $finder. Assuming the first.');
     }
     await pumpUntil(button.first);
     return tap(button.first);

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -27,7 +27,7 @@ class ReleasePage extends StatelessWidget {
     final selected = model.selectedRelease;
     final l10n = AppLocalizations.of(context);
     final String action;
-    final String dialogText;
+    String dialogText;
 
     if (selected?.isDowngrade == true) {
       action = l10n.downgrade;
@@ -49,6 +49,9 @@ class ReleasePage extends StatelessWidget {
         device.version,
         selected?.version,
       );
+    }
+    if (!device.flags.contains(FwupdDeviceFlag.usableDuringUpdate)) {
+      dialogText += ' ${l10n.deviceUnavailable}';
     }
 
     return Scaffold(

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -79,6 +79,7 @@ class ReleasePage extends StatelessWidget {
                     showConfirmationDialog(
                       context,
                       text: dialogText,
+                      okText: action,
                       onConfirm: () {
                         onInstall(selected);
                         Navigator.of(context).pop();

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -27,7 +27,10 @@ class ReleasePage extends StatelessWidget {
     final selected = model.selectedRelease;
     final l10n = AppLocalizations.of(context);
     final String action;
-    String dialogText;
+    final String dialogText;
+    final dialogDesc = device.flags.contains(FwupdDeviceFlag.usableDuringUpdate)
+        ? null
+        : l10n.deviceUnavailable;
 
     if (selected?.isDowngrade == true) {
       action = l10n.downgrade;
@@ -49,9 +52,6 @@ class ReleasePage extends StatelessWidget {
         device.version,
         selected?.version,
       );
-    }
-    if (!device.flags.contains(FwupdDeviceFlag.usableDuringUpdate)) {
-      dialogText += ' ${l10n.deviceUnavailable}';
     }
 
     return Scaffold(
@@ -82,6 +82,7 @@ class ReleasePage extends StatelessWidget {
                     showConfirmationDialog(
                       context,
                       text: dialogText,
+                      description: dialogDesc,
                       okText: action,
                       onConfirm: () {
                         onInstall(selected);

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -3,6 +3,7 @@
   "close": "Close",
   "cancel": "Cancel",
   "current": "Current",
+  "deviceUnavailable": "The device will be unavailable during this action.",
   "downgrade": "Downgrade",
   "downgradeConfirm": "Downgrade {name} from version {current} to {selected}?",
   "@downgradeConfirm": {

--- a/lib/src/widgets/confirmation_dialog.dart
+++ b/lib/src/widgets/confirmation_dialog.dart
@@ -5,6 +5,7 @@ import 'package:yaru_icons/yaru_icons.dart';
 Future<void> showConfirmationDialog(
   BuildContext context, {
   required String text,
+  String? description,
   String? okText,
   VoidCallback? onConfirm,
   VoidCallback? onCancel,
@@ -13,7 +14,6 @@ Future<void> showConfirmationDialog(
   final confirmed = await showDialog<bool>(
     context: context,
     builder: (context) => AlertDialog(
-      contentPadding: const EdgeInsets.all(16),
       actions: [
         OutlinedButton(
           onPressed: () => Navigator.of(context).pop(false),
@@ -24,15 +24,33 @@ Future<void> showConfirmationDialog(
           child: Text(okText ?? l10n.ok),
         ),
       ],
-      content: Row(
-        children: [
-          const Icon(
-            YaruIcons.question,
-            size: 64.0,
-          ),
-          const SizedBox(width: 16),
-          Flexible(child: Text(text)),
-        ],
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 500),
+        child: Row(
+          children: [
+            const Icon(
+              YaruIcons.question,
+              size: 64.0,
+            ),
+            const SizedBox(width: 16),
+            Flexible(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    text,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  if (description != null) ...[
+                    const SizedBox(height: 8),
+                    Text(description),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     ),
   );

--- a/lib/src/widgets/confirmation_dialog.dart
+++ b/lib/src/widgets/confirmation_dialog.dart
@@ -31,7 +31,7 @@ Future<void> showConfirmationDialog(
             size: 64.0,
           ),
           const SizedBox(width: 16),
-          Text(text),
+          Flexible(child: Text(text)),
         ],
       ),
     ),


### PR DESCRIPTION
Small improvements for the confirmation dialogs:
* buttons now read "Upgrade", "Downgrade", "Reinstall" instead of "OK" (and the integration test is now able to distinguish the button in the dialog from the one on the page \o/)
* dialog shows a notice if the device won't be available during the action

![Screenshot from 2022-09-21 13-18-28](https://user-images.githubusercontent.com/113362648/191491122-4b8f9ae4-e626-46f1-acc4-814732392e10.png)
