### PR TITLE
Show confirmation dialog before firmware verification

### DIFF
--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 
 import 'device_model.dart';
 import 'fwupd_l10n.dart';
+import 'src/widgets/confirmation_dialog.dart';
 import 'src/widgets/device_icon.dart';
 
 class DevicePage extends StatelessWidget {
@@ -111,7 +112,15 @@ class DevicePage extends StatelessWidget {
                   children: [
                     if (canVerify)
                       OutlinedButton(
-                        onPressed: onVerify,
+                        onPressed: () => showConfirmationDialog(
+                          context,
+                          text: l10n.verifyFirmwareConfirm(device.name),
+                          description: device.flags
+                                  .contains(FwupdDeviceFlag.usableDuringUpdate)
+                              ? null
+                              : l10n.deviceUnavailable,
+                          onConfirm: onVerify,
+                        ),
                         child: Text(l10n.verifyFirmware),
                       ),
                     if (releases.isNotEmpty)

--- a/lib/fwupd_x.dart
+++ b/lib/fwupd_x.dart
@@ -2,7 +2,8 @@ import 'package:fwupd/fwupd.dart';
 
 extension FwupdDeviceX on FwupdDevice {
   String get id => deviceId;
-  bool get canVerify => flags.contains(FwupdDeviceFlag.canVerify);
+  bool get canVerify =>
+      flags.contains(FwupdDeviceFlag.canVerify) && checksum != null;
   bool get isUpdatable =>
       flags.contains(FwupdDeviceFlag.updatable) ||
       flags.contains(FwupdDeviceFlag.updatableHidden);

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -88,6 +88,14 @@
   },
   "vendor": "Vendor",
   "verifyFirmware": "Verify Firmware",
+  "verifyFirmwareConfirm": "Verify firmware checksums of {name}?",
+  "@verifyFirmwareConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "currentVersion": "Current Version",
   "minVersion": "Minimum Version"
 }


### PR DESCRIPTION
* show a dialog before calling `onVerify`
* hide "Verify" button for devices that don't have a checksum