### PR TITLE
Silence the "nothing to do" exceptions

### DIFF
--- a/lib/firmware_model.dart
+++ b/lib/firmware_model.dart
@@ -78,13 +78,11 @@ class FirmwareModel extends SafeChangeNotifier {
       List<FwupdDevice> devices) async {
     Future<List<FwupdRelease>> fetchReleases(FwupdDevice device) {
       return _service.getReleases(device.id).catchError(
-        (e) {
-          log.debug('could not fetch releases for device ${device.id}: $e');
-          return <FwupdRelease>[];
-        },
-        test: (e) =>
-            e is FwupdNothingToDoException || e is FwupdNotSupportedException,
-      );
+            (_) => <FwupdRelease>[],
+            test: (e) =>
+                e is FwupdNothingToDoException ||
+                e is FwupdNotSupportedException,
+          );
     }
 
     final all = <String, List<FwupdRelease>>{};


### PR DESCRIPTION
With the 9 fwupd devices I have, it was logging 505 "nothing to do" messages during integration tests. :)