### PR TITLE
Bug fix: update device information after installing a new release

### DIFF
--- a/lib/firmware_body_page.dart
+++ b/lib/firmware_body_page.dart
@@ -17,9 +17,9 @@ class FirmwareBodyPage extends StatelessWidget {
     BuildContext context, {
     required FwupdDevice device,
   }) {
-    final firmwareModel = context.read<FirmwareModel>();
-    return ChangeNotifierProvider<DeviceModel>(
-      create: (_) => DeviceModel(firmwareModel, device),
+    return ChangeNotifierProxyProvider<FirmwareModel, DeviceModel>(
+      create: (_) => DeviceModel(context.read<FirmwareModel>(), device),
+      update: (_, firmwareModel, __) => DeviceModel(firmwareModel, device),
       child: const FirmwareBodyPage(),
     );
   }

--- a/lib/firmware_model.dart
+++ b/lib/firmware_model.dart
@@ -50,6 +50,8 @@ class FirmwareModel extends SafeChangeNotifier {
   Future<void> install(FwupdDevice device, FwupdRelease release) async {
     try {
       await _service.install(device, release);
+      await refresh();
+      return _updateState();
       // TODO: FwupdException
     } on Exception catch (error, stackTrace) {
       log.error('installation failed $error');

--- a/lib/firmware_model.dart
+++ b/lib/firmware_model.dart
@@ -50,8 +50,6 @@ class FirmwareModel extends SafeChangeNotifier {
   Future<void> install(FwupdDevice device, FwupdRelease release) async {
     try {
       await _service.install(device, release);
-      await refresh();
-      return _updateState();
       // TODO: FwupdException
     } on Exception catch (error, stackTrace) {
       log.error('installation failed $error');


### PR DESCRIPTION
I noticed that the version number didn't update after installing an update:

[Before](https://user-images.githubusercontent.com/113362648/191706995-a38ae013-b2fb-4da5-a2d6-555122bf7990.webm)

Fixed:

[After](https://user-images.githubusercontent.com/113362648/191707055-c6199d29-65f8-47f5-acd3-c81deebad396.webm)
