### PR TITLE
FwupdService: fix stream handling

### DIFF
--- a/lib/fwupd_service.dart
+++ b/lib/fwupd_service.dart
@@ -27,6 +27,7 @@ class FwupdService {
   final FwupdClient _fwupd;
   int? _downloadProgress;
   final _propertiesChanged = StreamController<List<String>>();
+  StreamSubscription<List<String>>? _propertiesSubscription;
 
   FwupdStatus get status =>
       _downloadProgress != null ? FwupdStatus.downloading : _fwupd.status;
@@ -40,11 +41,13 @@ class FwupdService {
 
   Future<void> init() async {
     await _fwupd.connect();
-    unawaited(_propertiesChanged.addStream(_fwupd.propertiesChanged));
+    _propertiesSubscription ??=
+        _fwupd.propertiesChanged.listen(_propertiesChanged.add);
   }
 
-  Future<void> dispose() {
+  Future<void> dispose() async {
     _dio.close();
+    await _propertiesSubscription?.cancel();
     return _fwupd.close();
   }
 

--- a/test/fwupd_service_test.dart
+++ b/test/fwupd_service_test.dart
@@ -55,6 +55,7 @@ void main() {
     );
 
     final service = FwupdService(fwupd: fwupd, dio: dio, fs: fs);
+    await service.init();
 
     await service.install(device, release, (f) => MockResourceHandle());
 


### PR DESCRIPTION
A StreamController is not allowed to call add() while addStream().

> Bad state: Cannot add event while adding a stream