### PR TITLE
cleanup DevicePage and ReleasePage

### DIFF
--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -6,24 +6,12 @@ import 'package:provider/provider.dart';
 
 import 'device_model.dart';
 import 'fwupd_l10n.dart';
+import 'fwupd_x.dart';
 import 'src/widgets/confirmation_dialog.dart';
 import 'src/widgets/device_icon.dart';
 
 class DevicePage extends StatelessWidget {
-  const DevicePage({
-    super.key,
-    required this.device,
-    required this.canVerify,
-    required this.onVerify,
-    required this.releases,
-    required this.hasUpgrade,
-  });
-
-  final FwupdDevice device;
-  final bool canVerify;
-  final VoidCallback onVerify;
-  final List<FwupdRelease> releases;
-  final bool hasUpgrade;
+  const DevicePage({super.key});
 
   static Widget _buildPadding(Widget child) {
     return Padding(
@@ -86,6 +74,9 @@ class DevicePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final model = context.watch<DeviceModel>();
+    final device = model.device;
+    final releases = model.releases ?? [];
     final l10n = AppLocalizations.of(context);
     final deviceFlags = [
       for (final flag in device.flags) flag.localize(context)
@@ -104,13 +95,13 @@ class DevicePage extends StatelessWidget {
                 device.vendor ?? '',
                 device.name,
                 device.summary ?? '',
-                DeviceIcon.fromName(device.icon.firstOrNull),
+                DeviceIcon.fromName(model.device.icon.firstOrNull),
               ),
-              if (canVerify || releases.isNotEmpty)
+              if (device.canVerify || releases.isNotEmpty)
                 ButtonBar(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (canVerify)
+                    if (device.canVerify)
                       OutlinedButton(
                         onPressed: () => showConfirmationDialog(
                           context,
@@ -119,12 +110,12 @@ class DevicePage extends StatelessWidget {
                                   .contains(FwupdDeviceFlag.usableDuringUpdate)
                               ? null
                               : l10n.deviceUnavailable,
-                          onConfirm: onVerify,
+                          onConfirm: model.verify,
                         ),
                         child: Text(l10n.verifyFirmware),
                       ),
                     if (releases.isNotEmpty)
-                      hasUpgrade
+                      model.hasUpgrade()
                           ? ElevatedButton(
                               onPressed: () => context
                                   .read<DeviceModel>()

--- a/lib/firmware_body_page.dart
+++ b/lib/firmware_body_page.dart
@@ -6,7 +6,6 @@ import 'package:yaru/yaru.dart';
 import 'device_model.dart';
 import 'device_page.dart';
 import 'firmware_model.dart';
-import 'fwupd_x.dart';
 import 'release_page.dart';
 
 class FirmwareBodyPage extends StatelessWidget {
@@ -35,22 +34,12 @@ class FirmwareBodyPage extends StatelessWidget {
         ),
         child: Navigator(
           pages: [
-            MaterialPage(
-              child: DevicePage(
-                device: deviceModel.device,
-                canVerify: deviceModel.device.canVerify,
-                onVerify: deviceModel.verify,
-                releases: deviceModel.releases ?? [],
-                hasUpgrade: deviceModel.hasUpgrade(),
-              ),
+            const MaterialPage(
+              child: DevicePage(),
             ),
             if (deviceModel.selectedRelease != null)
-              MaterialPage(
-                child: ReleasePage(
-                  device: deviceModel.device,
-                  releases: deviceModel.releases ?? [],
-                  onInstall: deviceModel.install,
-                ),
+              const MaterialPage(
+                child: ReleasePage(),
               )
           ],
           onPopPage: (route, result) => route.didPop(result),

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -10,20 +10,13 @@ import 'src/widgets/confirmation_dialog.dart';
 import 'src/widgets/release_card.dart';
 
 class ReleasePage extends StatelessWidget {
-  const ReleasePage({
-    super.key,
-    required this.device,
-    required this.releases,
-    required this.onInstall,
-  });
-
-  final FwupdDevice device;
-  final List<FwupdRelease> releases;
-  final ValueChanged<FwupdRelease> onInstall;
+  const ReleasePage({super.key});
 
   @override
   Widget build(BuildContext context) {
     final model = context.watch<DeviceModel>();
+    final device = model.device;
+    final releases = model.releases ?? [];
     final selected = model.selectedRelease;
     final l10n = AppLocalizations.of(context);
     final String action;
@@ -86,7 +79,7 @@ class ReleasePage extends StatelessWidget {
                       description: dialogDesc,
                       okText: action,
                       onConfirm: () {
-                        onInstall(selected);
+                        model.install(selected);
                         Navigator.of(context).pop();
                       },
                       onCancel: () {},


### PR DESCRIPTION
access device properties and methods through provider instead of parameters and callbacks