### PR TITLE
Add button to update device checksums

### DIFF
--- a/lib/device_model.dart
+++ b/lib/device_model.dart
@@ -21,6 +21,7 @@ class DeviceModel extends SafeChangeNotifier {
   List<FwupdRelease>? get releases => _releases;
 
   Future<void> verify() => _firmwareModel.verify(_device);
+  Future<void> verifyUpdate() => _firmwareModel.verifyUpdate(_device);
   Future<void> install(FwupdRelease release) =>
       _firmwareModel.install(_device, release);
   bool hasUpgrade() => _firmwareModel.state.hasUpgrade(_device);

--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -101,7 +101,7 @@ class DevicePage extends StatelessWidget {
                 ButtonBar(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (device.canVerify)
+                    if (device.canVerify && device.checksum != null)
                       OutlinedButton(
                         onPressed: () => showConfirmationDialog(
                           context,

--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -101,6 +101,17 @@ class DevicePage extends StatelessWidget {
                 ButtonBar(
                   mainAxisSize: MainAxisSize.min,
                   children: [
+                    if (device.canVerify)
+                      OutlinedButton(
+                        onPressed: () => showConfirmationDialog(
+                          context,
+                          text: l10n.updateChecksumsConfirm(device.name),
+                          description: l10n.updateChecksumsInfo,
+                          onConfirm: model.verifyUpdate,
+                          okText: l10n.update,
+                        ),
+                        child: Text(l10n.updateChecksums),
+                      ),
                     if (device.canVerify && device.checksum != null)
                       OutlinedButton(
                         onPressed: () => showConfirmationDialog(

--- a/lib/firmware_model.dart
+++ b/lib/firmware_model.dart
@@ -68,7 +68,7 @@ class FirmwareModel extends SafeChangeNotifier {
   Future<FirmwareState> _fetchState() async {
     try {
       return FirmwareState.data(
-        devices: _monitor.devices,
+        devices: List.of(_monitor.devices),
         releases: await _fetchReleases(_monitor.devices),
       );
     } on FwupdException catch (_) {

--- a/lib/firmware_model.dart
+++ b/lib/firmware_model.dart
@@ -62,6 +62,8 @@ class FirmwareModel extends SafeChangeNotifier {
   }
 
   Future<void> verify(FwupdDevice device) => _service.verify(device);
+  Future<void> verifyUpdate(FwupdDevice device) =>
+      _service.verifyUpdate(device);
 
   Future<FirmwareState> _fetchState() async {
     try {

--- a/lib/fwupd_x.dart
+++ b/lib/fwupd_x.dart
@@ -2,8 +2,7 @@ import 'package:fwupd/fwupd.dart';
 
 extension FwupdDeviceX on FwupdDevice {
   String get id => deviceId;
-  bool get canVerify =>
-      flags.contains(FwupdDeviceFlag.canVerify) && checksum != null;
+  bool get canVerify => flags.contains(FwupdDeviceFlag.canVerify);
   bool get isUpdatable =>
       flags.contains(FwupdDeviceFlag.updatable) ||
       flags.contains(FwupdDeviceFlag.updatableHidden);

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -70,7 +70,18 @@
   },
   "showReleases": "Show Releases",
   "showUpdates": "Show Updates",
+  "update": "Update",
   "updateAvailable": "Update available",
+  "updateChecksums": "Update Checksums",
+  "updateChecksumsConfirm": "Update device checksums of {name}?",
+  "@updateChecksumsConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "updateChecksumsInfo": "This will record the current cryptographic hashes as verified.",
   "upgrade": "Upgrade",
   "upgradeConfirm": "Upgrade {name} from version {current} to {selected}?",
   "@upgradeConfirm": {

--- a/test/firmare_page_test.mocks.dart
+++ b/test/firmare_page_test.mocks.dart
@@ -210,6 +210,15 @@ class MockFirmwareModel extends _i1.Mock implements _i7.FirmwareModel {
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
   @override
+  _i5.Future<void> verifyUpdate(_i4.FwupdDevice? device) => (super.noSuchMethod(
+        Invocation.method(
+          #verifyUpdate,
+          [device],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,

--- a/test/firmware_model_test.dart
+++ b/test/firmware_model_test.dart
@@ -95,4 +95,14 @@ void main() {
     await model.verify(device);
     verify(service.verify(device)).called(1);
   });
+
+  test('verify update', () async {
+    final device = testDevice(id: '');
+
+    final service = mockService();
+
+    final model = FirmwareModel(service);
+    await model.verifyUpdate(device);
+    verify(service.verifyUpdate(device)).called(1);
+  });
 }


### PR DESCRIPTION
* add `verifyUpdate` methods to `FirmwareModel` and `DeviceModel` (instructs the fwupd service to update a device's checksums)
* revert changes to `canVerify` method introduced in #65 - it should reflect the devices capability to verify a checksum, regardless of whether it currently has a checksum or not.
* add 'Update checksums button'