### PR TITLE
ReleasePage: tweak app bar & back button looks

### DIFF
--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -50,10 +50,14 @@ class ReleasePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text('${device.name} ${device.version}'),
-        leading: IconButton(
-          onPressed: Navigator.of(context).pop,
-          icon: const Icon(YaruIcons.go_previous),
+        leading: Center(
+          child: IconButton(
+            style: IconButton.styleFrom(fixedSize: const Size(40, 40)),
+            onPressed: Navigator.of(context).pop,
+            icon: const Icon(YaruIcons.go_previous),
+          ),
         ),
+        elevation: 0,
       ),
       body: ListView(
         padding: const EdgeInsets.symmetric(horizontal: 16),


### PR DESCRIPTION
- remove the separator until scrolled under to give it less boxy looks
- ensure that the back button stays round

![Screenshot from 2022-09-23 14-45-28](https://user-images.githubusercontent.com/140617/191963395-d10cf9b6-618a-486f-a8c9-3cf9d2c1d245.png)

![Screenshot from 2022-09-23 14-45-38](https://user-images.githubusercontent.com/140617/191963434-965b4afb-0bb0-4704-8248-125d2865a9f5.png)

Close: #70
