### PR TITLE
Reboot

### DIFF
--- a/lib/device_model.dart
+++ b/lib/device_model.dart
@@ -10,6 +10,8 @@ class DeviceModel extends SafeChangeNotifier {
   FirmwareModel _firmwareModel;
   List<FwupdRelease>? _releases;
 
+  Future<void> reboot() => _firmwareModel.reboot();
+
   void update(FirmwareModel firmwareModel) {
     _firmwareModel = firmwareModel;
     _releases = _firmwareModel.state.getReleases(_device);

--- a/lib/device_model.dart
+++ b/lib/device_model.dart
@@ -10,6 +10,13 @@ class DeviceModel extends SafeChangeNotifier {
   FirmwareModel _firmwareModel;
   List<FwupdRelease>? _releases;
 
+  var _state = DeviceState.idle;
+  DeviceState get state => _state;
+  set state(DeviceState state) {
+    _state = state;
+    notifyListeners();
+  }
+
   Future<void> reboot() => _firmwareModel.reboot();
 
   void update(FirmwareModel firmwareModel) {
@@ -36,4 +43,10 @@ class DeviceModel extends SafeChangeNotifier {
   Future<void> install(FwupdRelease release) =>
       _firmwareModel.install(_device, release);
   bool hasUpgrade() => _firmwareModel.state.hasUpgrade(_device);
+}
+
+enum DeviceState {
+  idle,
+  busy,
+  needsReboot,
 }

--- a/lib/device_model.dart
+++ b/lib/device_model.dart
@@ -6,9 +6,18 @@ import 'firmware_model.dart';
 class DeviceModel extends SafeChangeNotifier {
   DeviceModel(this._firmwareModel, this._device)
       : _releases = _firmwareModel.state.getReleases(_device);
-  final FirmwareModel _firmwareModel;
   final FwupdDevice _device;
-  final List<FwupdRelease>? _releases;
+  FirmwareModel _firmwareModel;
+  List<FwupdRelease>? _releases;
+
+  void update(FirmwareModel firmwareModel) {
+    _firmwareModel = firmwareModel;
+    _releases = _firmwareModel.state.getReleases(_device);
+    if (_selectedRelease != null) {
+      _selectedRelease = _releases?.singleWhere(
+          (release) => release.version == _selectedRelease?.version);
+    }
+  }
 
   FwupdRelease? _selectedRelease;
   FwupdRelease? get selectedRelease => _selectedRelease;

--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -81,6 +81,18 @@ class DevicePage extends StatelessWidget {
     final deviceFlags = [
       for (final flag in device.flags) flag.localize(context)
     ].whereNotNull();
+
+    if (model.state == DeviceState.needsReboot) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => showConfirmationDialog(
+          context,
+          text: l10n.rebootConfirm,
+          okText: l10n.reboot,
+          onCancel: () => model.state = DeviceState.idle,
+          onConfirm: model.reboot,
+        ),
+      );
+    }
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Column(

--- a/lib/firmware_body_page.dart
+++ b/lib/firmware_body_page.dart
@@ -19,7 +19,10 @@ class FirmwareBodyPage extends StatelessWidget {
   }) {
     return ChangeNotifierProxyProvider<FirmwareModel, DeviceModel>(
       create: (_) => DeviceModel(context.read<FirmwareModel>(), device),
-      update: (_, firmwareModel, __) => DeviceModel(firmwareModel, device),
+      update: (_, firmwareModel, oldModel) {
+        if (oldModel == null) return DeviceModel(firmwareModel, device);
+        return oldModel..update(firmwareModel);
+      },
       child: const FirmwareBodyPage(),
     );
   }

--- a/lib/firmware_model.dart
+++ b/lib/firmware_model.dart
@@ -39,6 +39,7 @@ class FirmwareModel extends SafeChangeNotifier {
     ]).then((_) => _updateState());
   }
 
+  Future<void> reboot() => _service.reboot();
   Future<void> refresh() => _monitor.refresh();
 
   @override

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -48,18 +48,6 @@ class ReleasePage extends StatelessWidget {
       );
     }
 
-    if (model.state == DeviceState.needsReboot) {
-      WidgetsBinding.instance.addPostFrameCallback(
-        (_) => showConfirmationDialog(
-          context,
-          text: l10n.rebootConfirm,
-          okText: l10n.reboot,
-          onCancel: () => model.state = DeviceState.idle,
-          onConfirm: model.reboot,
-        ),
-      );
-    }
-
     return model.state == DeviceState.busy
         ? const Center(child: YaruCircularProgressIndicator())
         : Scaffold(
@@ -94,6 +82,7 @@ class ReleasePage extends StatelessWidget {
                             description: dialogDesc,
                             okText: action,
                             onConfirm: () async {
+                              model.selectedRelease = null;
                               model.state = DeviceState.busy;
                               await model.install(selected);
                               model.state = device.flags

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -56,6 +56,8 @@
   "fwupdDeviceFlagUnsignedPayload": "Unsigned Payload",
   "guid": "GUIDs",
   "ok": "OK",
+  "reboot": "Reboot",
+  "rebootConfirm": "The update requires a reboot to complete. Do you want to reboot now?",
   "reinstall": "Reinstall",
   "reinstallConfirm": "Reinstall {name} version {current}?",
   "@reinstallConfirm": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
+  dbus: ^0.7.3
   dio: ^4.0.0
   file: ^6.1.2
   flutter:
@@ -22,6 +23,9 @@ dependencies:
   path: ^1.8.0
   provider: ^6.0.0
   safe_change_notifier: ^0.1.0
+  session_manager:
+    git:
+      url: https://github.com/canonical/session_manager.dart.git
   ubuntu_logger:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git

--- a/test/firmare_page_test.mocks.dart
+++ b/test/firmare_page_test.mocks.dart
@@ -168,6 +168,15 @@ class MockFirmwareModel extends _i1.Mock implements _i7.FirmwareModel {
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
   @override
+  _i5.Future<void> reboot() => (super.noSuchMethod(
+        Invocation.method(
+          #reboot,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
   _i5.Future<void> refresh() => (super.noSuchMethod(
         Invocation.method(
           #refresh,

--- a/test/fwupd_service_test.mocks.dart
+++ b/test/fwupd_service_test.mocks.dart
@@ -19,6 +19,7 @@ import 'package:fwupd/src/fwupd_plugin.dart' as _i12;
 import 'package:fwupd/src/fwupd_release.dart' as _i13;
 import 'package:fwupd/src/fwupd_remote.dart' as _i15;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:session_manager/src/session_manager.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -1024,6 +1025,78 @@ class MockFwupdClient extends _i1.Mock implements _i10.FwupdClient {
         Invocation.method(
           #clearResults,
           [id],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+  @override
+  _i8.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+}
+
+/// A class which mocks [SessionManager].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockSessionManager extends _i1.Mock implements _i16.SessionManager {
+  MockSessionManager() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  bool get sessionIsActive => (super.noSuchMethod(
+        Invocation.getter(#sessionIsActive),
+        returnValue: false,
+      ) as bool);
+  @override
+  String get sessionName => (super.noSuchMethod(
+        Invocation.getter(#sessionName),
+        returnValue: '',
+      ) as String);
+  @override
+  _i8.Future<void> reboot() => (super.noSuchMethod(
+        Invocation.method(
+          #reboot,
+          [],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+  @override
+  _i8.Future<void> shutdown() => (super.noSuchMethod(
+        Invocation.method(
+          #shutdown,
+          [],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+  @override
+  _i8.Future<bool> canShutdown() => (super.noSuchMethod(
+        Invocation.method(
+          #canShutdown,
+          [],
+        ),
+        returnValue: _i8.Future<bool>.value(false),
+      ) as _i8.Future<bool>);
+  @override
+  _i8.Future<bool> isSessionRunning() => (super.noSuchMethod(
+        Invocation.method(
+          #isSessionRunning,
+          [],
+        ),
+        returnValue: _i8.Future<bool>.value(false),
+      ) as _i8.Future<bool>);
+  @override
+  _i8.Future<void> connect() => (super.noSuchMethod(
+        Invocation.method(
+          #connect,
+          [],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -202,4 +202,13 @@ class MockFwupdService extends _i1.Mock implements _i2.FwupdService {
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> reboot() => (super.noSuchMethod(
+        Invocation.method(
+          #reboot,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }


### PR DESCRIPTION
* include [session_manager.dart](https://github.com/canonical/session_manager.dart) package from github, which calls `org.gnome.SessionManager.Reboot()` over DBus
* implement `reboot()` method in `FwupdService`
* call `reboot()` after `install()` if device flag `FwupdDeviceFlag.needsReboot` is set

closes #42