### PR TITLE
Use updated Yaru Widgets

### DIFF
--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -35,44 +35,6 @@ class DevicePage extends StatelessWidget {
     return _buildPadding(Text(text));
   }
 
-  static Widget _buildIconRow(
-    BuildContext context,
-    String vendor,
-    String name,
-    String description,
-    IconData icon,
-  ) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(
-          icon,
-          size: 64,
-        ),
-        const SizedBox(width: 16),
-        Flexible(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                vendor,
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-              Text(
-                name,
-                style: Theme.of(context).textTheme.headlineSmall,
-              ),
-              Text(
-                description,
-                style: Theme.of(context).textTheme.labelMedium,
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final model = context.watch<DeviceModel>();

--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -3,12 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
 import 'package:provider/provider.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'device_model.dart';
 import 'fwupd_l10n.dart';
+import 'fwupd_notifier.dart';
 import 'fwupd_x.dart';
-import 'src/widgets/confirmation_dialog.dart';
-import 'src/widgets/device_icon.dart';
+import 'widgets.dart';
 
 class DevicePage extends StatelessWidget {
   const DevicePage({super.key});
@@ -75,6 +76,7 @@ class DevicePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final model = context.watch<DeviceModel>();
+    final notifier = context.watch<FwupdNotifier>();
     final device = model.device;
     final releases = model.releases ?? [];
     final l10n = AppLocalizations.of(context);
@@ -102,68 +104,61 @@ class DevicePage extends StatelessWidget {
         ),
       );
     }
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Column(
+    return YaruDetailPage(
+      appBar: AppProgressBar(
+        title: device.name,
+        leading: Icon(DeviceIcon.fromName(device.icon.firstOrNull)),
+        status: notifier.status,
+        progress: notifier.percentage / 100.0,
+      ),
+      body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Wrap(
-            alignment: WrapAlignment.spaceBetween,
-            runSpacing: 16.0,
-            children: [
-              DevicePage._buildIconRow(
-                context,
-                device.vendor ?? '',
-                device.name,
-                device.summary ?? '',
-                DeviceIcon.fromName(model.device.icon.firstOrNull),
-              ),
-              if (device.canVerify || releases.isNotEmpty)
-                ButtonBar(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (device.canVerify)
-                      OutlinedButton(
-                        onPressed: () => showConfirmationDialog(
-                          context,
-                          title: l10n.updateChecksumsConfirm(device.name),
-                          message: l10n.updateChecksumsInfo,
-                          onConfirm: model.verifyUpdate,
-                          actionText: l10n.update,
+          if (device.canVerify || releases.isNotEmpty)
+            ButtonBar(
+              mainAxisSize: MainAxisSize.min,
+              overflowButtonSpacing: 8.0,
+              children: [
+                if (device.canVerify)
+                  OutlinedButton(
+                    onPressed: () => showConfirmationDialog(
+                      context,
+                      title: l10n.updateChecksumsConfirm(device.name),
+                      message: l10n.updateChecksumsInfo,
+                      onConfirm: model.verifyUpdate,
+                      actionText: l10n.update,
+                    ),
+                    child: Text(l10n.updateChecksums),
+                  ),
+                if (device.canVerify && device.checksum != null)
+                  OutlinedButton(
+                    onPressed: () => showConfirmationDialog(
+                      context,
+                      title: l10n.verifyFirmwareConfirm(device.name),
+                      message: device.flags
+                              .contains(FwupdDeviceFlag.usableDuringUpdate)
+                          ? null
+                          : l10n.deviceUnavailable,
+                      onConfirm: model.verify,
+                    ),
+                    child: Text(l10n.verifyFirmware),
+                  ),
+                if (releases.isNotEmpty)
+                  model.hasUpgrade()
+                      ? ElevatedButton(
+                          onPressed: () => context
+                              .read<DeviceModel>()
+                              .selectedRelease = releases.first,
+                          child: Text(l10n.showUpdates),
+                        )
+                      : OutlinedButton(
+                          onPressed: () => context
+                              .read<DeviceModel>()
+                              .selectedRelease = releases.first,
+                          child: Text(l10n.showReleases),
                         ),
-                        child: Text(l10n.updateChecksums),
-                      ),
-                    if (device.canVerify && device.checksum != null)
-                      OutlinedButton(
-                        onPressed: () => showConfirmationDialog(
-                          context,
-                          title: l10n.verifyFirmwareConfirm(device.name),
-                          message: device.flags
-                                  .contains(FwupdDeviceFlag.usableDuringUpdate)
-                              ? null
-                              : l10n.deviceUnavailable,
-                          onConfirm: model.verify,
-                        ),
-                        child: Text(l10n.verifyFirmware),
-                      ),
-                    if (releases.isNotEmpty)
-                      model.hasUpgrade()
-                          ? ElevatedButton(
-                              onPressed: () => context
-                                  .read<DeviceModel>()
-                                  .selectedRelease = releases.first,
-                              child: Text(l10n.showUpdates),
-                            )
-                          : OutlinedButton(
-                              onPressed: () => context
-                                  .read<DeviceModel>()
-                                  .selectedRelease = releases.first,
-                              child: Text(l10n.showReleases),
-                            ),
-                  ],
-                ),
-            ],
-          ),
+              ],
+            ),
           const SizedBox(height: 32),
           Table(
             columnWidths: const {

--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -42,6 +42,7 @@ class DevicePage extends StatelessWidget {
     final device = model.device;
     final releases = model.releases ?? [];
     final l10n = AppLocalizations.of(context);
+    final fwupdIdle = notifier.status == FwupdStatus.idle;
     final deviceFlags = [
       for (final flag in device.flags) flag.localize(context)
     ].whereNotNull();
@@ -83,40 +84,48 @@ class DevicePage extends StatelessWidget {
               children: [
                 if (device.canVerify)
                   OutlinedButton(
-                    onPressed: () => showConfirmationDialog(
-                      context,
-                      title: l10n.updateChecksumsConfirm(device.name),
-                      message: l10n.updateChecksumsInfo,
-                      onConfirm: model.verifyUpdate,
-                      actionText: l10n.update,
-                    ),
+                    onPressed: fwupdIdle
+                        ? () => showConfirmationDialog(
+                              context,
+                              title: l10n.updateChecksumsConfirm(device.name),
+                              message: l10n.updateChecksumsInfo,
+                              onConfirm: model.verifyUpdate,
+                              actionText: l10n.update,
+                            )
+                        : null,
                     child: Text(l10n.updateChecksums),
                   ),
                 if (device.canVerify && device.checksum != null)
                   OutlinedButton(
-                    onPressed: () => showConfirmationDialog(
-                      context,
-                      title: l10n.verifyFirmwareConfirm(device.name),
-                      message: device.flags
-                              .contains(FwupdDeviceFlag.usableDuringUpdate)
-                          ? null
-                          : l10n.deviceUnavailable,
-                      onConfirm: model.verify,
-                    ),
+                    onPressed: fwupdIdle
+                        ? () => showConfirmationDialog(
+                              context,
+                              title: l10n.verifyFirmwareConfirm(device.name),
+                              message: device.flags.contains(
+                                      FwupdDeviceFlag.usableDuringUpdate)
+                                  ? null
+                                  : l10n.deviceUnavailable,
+                              onConfirm: model.verify,
+                            )
+                        : null,
                     child: Text(l10n.verifyFirmware),
                   ),
                 if (releases.isNotEmpty)
                   model.hasUpgrade()
                       ? ElevatedButton(
-                          onPressed: () => context
-                              .read<DeviceModel>()
-                              .selectedRelease = releases.first,
+                          onPressed: fwupdIdle
+                              ? () => context
+                                  .read<DeviceModel>()
+                                  .selectedRelease = releases.first
+                              : null,
                           child: Text(l10n.showUpdates),
                         )
                       : OutlinedButton(
-                          onPressed: () => context
-                              .read<DeviceModel>()
-                              .selectedRelease = releases.first,
+                          onPressed: fwupdIdle
+                              ? () => context
+                                  .read<DeviceModel>()
+                                  .selectedRelease = releases.first
+                              : null,
                           child: Text(l10n.showReleases),
                         ),
               ],

--- a/lib/firmware_app.dart
+++ b/lib/firmware_app.dart
@@ -45,7 +45,6 @@ class _FirmwareAppState extends State<FirmwareApp> {
             DetailPage.create(context, device: devices[index]),
         tileBuilder: (context, index, selected) =>
             DeviceTile.create(context, device: devices[index]),
-        titleBuilder: (context, index, selected) => Text(devices[index].name),
         leftPaneWidth: 400,
       ),
       empty: () => const Center(child: YaruCircularProgressIndicator()),

--- a/lib/firmware_app.dart
+++ b/lib/firmware_app.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -9,7 +8,6 @@ import 'device_store.dart';
 import 'device_tile.dart';
 import 'fwupd_notifier.dart';
 import 'fwupd_service.dart';
-import 'widgets.dart';
 
 class FirmwareApp extends StatefulWidget {
   const FirmwareApp({super.key});
@@ -34,6 +32,7 @@ class _FirmwareAppState extends State<FirmwareApp> {
   void initState() {
     super.initState();
     context.read<DeviceStore>().init();
+    context.read<FwupdNotifier>().init();
   }
 
   @override
@@ -41,19 +40,12 @@ class _FirmwareAppState extends State<FirmwareApp> {
     final store = context.watch<DeviceStore>();
     return store.when(
       devices: (devices) => YaruMasterDetailPage(
-        pageItems: devices
-            .map((device) => YaruPageItem(
-                  titleBuilder: (context) => DeviceTile.create(
-                    context,
-                    device: device,
-                  ),
-                  builder: (context) => DetailPage.create(
-                    context,
-                    device: device,
-                  ),
-                  iconData: DeviceIcon.fromName(device.icon.firstOrNull),
-                ))
-            .toList(),
+        length: devices.length,
+        pageBuilder: (context, index) =>
+            DetailPage.create(context, device: devices[index]),
+        tileBuilder: (context, index, selected) =>
+            DeviceTile.create(context, device: devices[index]),
+        titleBuilder: (context, index, selected) => Text(devices[index].name),
         leftPaneWidth: 400,
       ),
       empty: () => const Center(child: YaruCircularProgressIndicator()),

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
 import 'package:provider/provider.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'device_model.dart';
@@ -52,13 +51,9 @@ class ReleasePage extends StatelessWidget {
 
     return model.state == DeviceState.busy
         ? const Center(child: YaruCircularProgressIndicator())
-        : Scaffold(
+        : YaruDetailPage(
             appBar: AppBar(
               title: Text('${device.name} ${device.version}'),
-              leading: IconButton(
-                onPressed: Navigator.of(context).pop,
-                icon: const Icon(YaruIcons.go_previous),
-              ),
             ),
             body: ListView(
               padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/src/widgets/app_progress_bar.dart
+++ b/lib/src/widgets/app_progress_bar.dart
@@ -1,17 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:fwupd/fwupd.dart';
 
-import '../../fwupd_x.dart';
-import 'refresh_button.dart';
-
 class AppProgressBar extends AppBar {
   AppProgressBar({
     super.key,
     required String title,
+    super.leading,
     double? height,
     double? progress,
     required FwupdStatus status,
-    required VoidCallback onRefresh,
   }) : super(
           title: Text(title),
           bottom: PreferredSize(
@@ -25,9 +22,5 @@ class AppProgressBar extends AppBar {
               child: LinearProgressIndicator(value: progress),
             ),
           ),
-          actions: <Widget>[
-            RefreshButton(isBusy: status.isBusy, onPressed: onRefresh),
-            const SizedBox(width: 8),
-          ],
         );
 }

--- a/lib/src/widgets/device_header.dart
+++ b/lib/src/widgets/device_header.dart
@@ -17,27 +17,21 @@ class DeviceHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    return Stack(
-      children: [
-        ListTile(
-          title: Text(device.name),
-          subtitle: Text(device.summary ?? ''),
-          contentPadding: const EdgeInsets.only(left: 24),
-        ),
-        if (hasUpgrade)
-          Align(
-            alignment: Alignment.centerRight,
-            child: SmallChip(
-              text: l10n.updateAvailable,
+    return YaruMasterTile(
+      title: Text(device.name),
+      subtitle: Text(device.summary ?? ''),
+      leading: Icon(DeviceIcon.fromName(device.icon.firstOrNull)),
+      trailing: hasUpgrade
+          ? SmallChip(
+              text: l10n.update,
               color: Theme.of(context)
                       .elevatedButtonTheme
                       .style!
                       .backgroundColor!
                       .resolve({}) ??
                   Theme.of(context).primaryColor,
-            ),
-          ),
-      ],
+            )
+          : null,
     );
   }
 }

--- a/lib/src/widgets/device_header.dart
+++ b/lib/src/widgets/device_header.dart
@@ -1,7 +1,10 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
+import 'device_icon.dart';
 import 'small_chip.dart';
 
 class DeviceHeader extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,10 @@ dependencies:
   yaru: ^0.4.1
   yaru_colors: ^0.1.0
   yaru_icons: ^0.2.1
-  yaru_widgets: ^1.1.3
+  # yaru_widgets: ^1.1.3
+  yaru_widgets:
+    git:
+      url: https://github.com/ubuntu/yaru_widgets.dart
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/test/firmware_app_test.dart
+++ b/test/firmware_app_test.dart
@@ -67,7 +67,7 @@ void main() {
 
     // First device appears twice in master detail layout
     expect(find.text('Device 1'), findsNWidgets(2));
-    expect(find.text('Summary 1'), findsNWidgets(2));
+    expect(find.text('Summary 1'), findsOneWidget);
 
     expect(find.text('Device 2'), findsOneWidget);
     expect(find.text('Summary 2'), findsOneWidget);

--- a/test/widgets/app_progress_bar_test.dart
+++ b/test/widgets/app_progress_bar_test.dart
@@ -13,7 +13,6 @@ void main() {
           title: 'title',
           status: FwupdStatus.deviceWrite,
           progress: 0.5,
-          onRefresh: () {},
         ),
       ),
     ));
@@ -30,7 +29,6 @@ void main() {
         appBar: AppProgressBar(
           title: 'title',
           status: FwupdStatus.idle,
-          onRefresh: () {},
         ),
       ),
     ));


### PR DESCRIPTION
~~WIP~~
I'm testing the updated Yaru widgets to see if we can use them to improve the UI.

- use new `YaruMasterDetailPage`, `YaruMasterTile`, `YaruDetailPage`
- use `AppProgressBar` in `DevicePage` (and a simple `AppBar` in `ReleasePage` for now)

~~Current state:~~

~~[Screencast from 11-10-22 16:18:14.webm](https://user-images.githubusercontent.com/113362648/195116642-6ed17876-e3c4-4cc1-922c-7c670b66bf56.webm)~~
