### PR TITLE
always show cancel button on confirmation dialog

### DIFF
--- a/lib/src/widgets/confirmation_dialog.dart
+++ b/lib/src/widgets/confirmation_dialog.dart
@@ -91,7 +91,7 @@ Future<DialogAction?> showConfirmationDialog(
       message: message,
       actionText: actionText,
       icon: const Icon(YaruIcons.question, size: 64.0),
-      onCancel: onCancel,
+      onCancel: onCancel ?? () {},
       onAction: onConfirm,
       closeable: false,
     );

--- a/test/widgets/message_dialog_test.dart
+++ b/test/widgets/message_dialog_test.dart
@@ -58,7 +58,6 @@ void main() {
               title: title,
               message: message,
               onConfirm: completer.complete,
-              onCancel: () {},
             ),
             child: const Text('click me'),
           );


### PR DESCRIPTION
Make sure to always show the cancel button, even if `onCancel` is not provided.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/113362648/195122350-5e26eb7f-02a9-48d7-a9db-01e9bd095424.png) | ![image](https://user-images.githubusercontent.com/113362648/195121915-868ce074-d21d-40db-8c8d-b2efce5082a8.png) |
