### PR TITLE
Battery warning

### DIFF
--- a/lib/firmware_app.dart
+++ b/lib/firmware_app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -8,6 +9,7 @@ import 'device_store.dart';
 import 'device_tile.dart';
 import 'fwupd_notifier.dart';
 import 'fwupd_service.dart';
+import 'widgets.dart';
 
 class FirmwareApp extends StatefulWidget {
   const FirmwareApp({super.key});
@@ -38,14 +40,19 @@ class _FirmwareAppState extends State<FirmwareApp> {
   @override
   Widget build(BuildContext context) {
     final store = context.watch<DeviceStore>();
+    final notifier = context.watch<FwupdNotifier>();
+    final l10n = AppLocalizations.of(context);
     return store.when(
-      devices: (devices) => YaruMasterDetailPage(
-        length: devices.length,
-        pageBuilder: (context, index) =>
-            DetailPage.create(context, device: devices[index]),
-        tileBuilder: (context, index, selected) =>
-            DeviceTile.create(context, device: devices[index]),
-        leftPaneWidth: 400,
+      devices: (devices) => ErrorBanner(
+        message: notifier.onBattery ? l10n.batteryWarning : null,
+        child: YaruMasterDetailPage(
+          length: devices.length,
+          pageBuilder: (context, index) =>
+              DetailPage.create(context, device: devices[index]),
+          tileBuilder: (context, index, selected) =>
+              DeviceTile.create(context, device: devices[index]),
+          leftPaneWidth: 400,
+        ),
       ),
       empty: () => const Center(child: YaruCircularProgressIndicator()),
     );

--- a/lib/fwupd_notifier.dart
+++ b/lib/fwupd_notifier.dart
@@ -17,6 +17,7 @@ class FwupdNotifier extends SafeChangeNotifier {
   FwupdStatus get status => _service.status;
   int get percentage => _service.percentage;
   String get version => _service.daemonVersion;
+  bool get onBattery => _service.onBattery;
 
   Future<void> init() async {
     _propertiesChanged ??= _service.propertiesChanged.listen((properties) {
@@ -28,6 +29,10 @@ class FwupdNotifier extends SafeChangeNotifier {
             break;
           case 'Percentage':
             log.debug('$percentage%');
+            notifyListeners();
+            break;
+          case 'OnBattery':
+            log.debug('on battery: $onBattery');
             notifyListeners();
             break;
           default:

--- a/lib/fwupd_service.dart
+++ b/lib/fwupd_service.dart
@@ -57,6 +57,7 @@ class FwupdService {
     await _upower.connect();
     _upowerPropertiesSubscription ??=
         _upower.propertiesChanged.listen(_propertiesChanged.add);
+    _propertiesChanged.add(['OnBattery']);
   }
 
   Future<void> dispose() async {

--- a/lib/fwupd_service.dart
+++ b/lib/fwupd_service.dart
@@ -37,7 +37,8 @@ class FwupdService {
   final UbuntuSession _session;
   int? _downloadProgress;
   final _propertiesChanged = StreamController<List<String>>();
-  StreamSubscription<List<String>>? _propertiesSubscription;
+  StreamSubscription<List<String>>? _fwupdPropertiesSubscription;
+  StreamSubscription<List<String>>? _upowerPropertiesSubscription;
 
   FwupdStatus get status =>
       _downloadProgress != null ? FwupdStatus.downloading : _fwupd.status;
@@ -51,15 +52,18 @@ class FwupdService {
 
   Future<void> init() async {
     await _fwupd.connect();
-    _propertiesSubscription ??=
+    _fwupdPropertiesSubscription ??=
         _fwupd.propertiesChanged.listen(_propertiesChanged.add);
     await _upower.connect();
+    _upowerPropertiesSubscription ??=
+        _upower.propertiesChanged.listen(_propertiesChanged.add);
   }
 
   Future<void> dispose() async {
     _dio.close();
+    await _fwupdPropertiesSubscription?.cancel();
+    await _upowerPropertiesSubscription?.cancel();
     await _upower.close();
-    await _propertiesSubscription?.cancel();
     return _fwupd.close();
   }
 

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1,5 +1,6 @@
 {
   "appTitle": "Firmware Updater",
+  "batteryWarning": "Warning: some device updates may only be available on external power!",
   "close": "Close",
   "cancel": "Cancel",
   "current": "Current",

--- a/lib/src/widgets/error_banner.dart
+++ b/lib/src/widgets/error_banner.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class ErrorBanner extends StatefulWidget {
+  const ErrorBanner({
+    required this.child,
+    this.message,
+    super.key,
+  });
+
+  final Widget child;
+  final String? message;
+
+  @override
+  State<ErrorBanner> createState() => _ErrorBannerState();
+}
+
+class _ErrorBannerState extends State<ErrorBanner> {
+  bool _visible = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (widget.message != null && _visible)
+          Container(
+            color: Theme.of(context).colorScheme.error,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    widget.message!,
+                    style: Theme.of(context).textTheme.labelMedium!.copyWith(
+                          color: Theme.of(context).colorScheme.onError,
+                        ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                IconButton(
+                  onPressed: () => setState(() => _visible = false),
+                  icon: const Icon(Icons.close, size: 16),
+                  padding: EdgeInsets.zero,
+                  visualDensity: const VisualDensity(
+                    horizontal: -4,
+                    vertical: -4,
+                  ),
+                  color: Theme.of(context).colorScheme.onError,
+                )
+              ],
+            ),
+          ),
+        Expanded(child: widget.child),
+      ],
+    );
+  }
+}

--- a/lib/src/widgets/error_banner.dart
+++ b/lib/src/widgets/error_banner.dart
@@ -19,38 +19,40 @@ class _ErrorBannerState extends State<ErrorBanner> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        if (widget.message != null && _visible)
-          Container(
-            color: Theme.of(context).colorScheme.error,
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    widget.message!,
-                    style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onError,
-                        ),
-                    textAlign: TextAlign.center,
+    return Material(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (widget.message != null && _visible)
+            Container(
+              color: Theme.of(context).colorScheme.error,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      widget.message!,
+                      style: Theme.of(context).textTheme.labelMedium!.copyWith(
+                            color: Theme.of(context).colorScheme.onError,
+                          ),
+                      textAlign: TextAlign.center,
+                    ),
                   ),
-                ),
-                IconButton(
-                  onPressed: () => setState(() => _visible = false),
-                  icon: const Icon(Icons.close, size: 16),
-                  padding: EdgeInsets.zero,
-                  visualDensity: const VisualDensity(
-                    horizontal: -4,
-                    vertical: -4,
-                  ),
-                  color: Theme.of(context).colorScheme.onError,
-                )
-              ],
+                  IconButton(
+                    onPressed: () => setState(() => _visible = false),
+                    icon: const Icon(Icons.close, size: 16),
+                    padding: EdgeInsets.zero,
+                    visualDensity: const VisualDensity(
+                      horizontal: -4,
+                      vertical: -4,
+                    ),
+                    color: Theme.of(context).colorScheme.onError,
+                  )
+                ],
+              ),
             ),
-          ),
-        Expanded(child: widget.child),
-      ],
+          Expanded(child: widget.child),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -3,6 +3,7 @@ export 'src/widgets/confirmation_dialog.dart';
 export 'src/widgets/device_header.dart';
 export 'src/widgets/device_icon.dart';
 export 'src/widgets/device_panel_list.dart';
+export 'src/widgets/error_banner.dart';
 export 'src/widgets/option_card.dart';
 export 'src/widgets/refresh_button.dart';
 export 'src/widgets/release_card.dart';

--- a/test/firmware_app_test.dart
+++ b/test/firmware_app_test.dart
@@ -74,4 +74,17 @@ void main() {
     expect(find.text('Device 2'), findsOneWidget);
     expect(find.text('Summary 2'), findsOneWidget);
   });
+
+  testWidgets('on battery', (tester) async {
+    registerMockService<FwupdService>(mockService());
+
+    final store = mockStore(devices: [
+      testDevice(id: '1', name: 'Device 1', summary: 'Summary 1'),
+      testDevice(id: '2', name: 'Device 2', summary: 'Summary 2'),
+    ]);
+    await tester.pumpApp((_) =>
+        buildPage(store: store, notifier: mockNotifier(onBattery: true)));
+
+    expect(find.text(tester.lang.batteryWarning), findsOneWidget);
+  });
 }

--- a/test/firmware_app_test.dart
+++ b/test/firmware_app_test.dart
@@ -28,11 +28,13 @@ void main() {
     FwupdStatus? status,
     int? percentage,
     String? version,
+    bool? onBattery,
   }) {
     final notifier = MockFwupdNotifier();
     when(notifier.status).thenReturn(status ?? FwupdStatus.idle);
     when(notifier.percentage).thenReturn(percentage ?? 0);
     when(notifier.version).thenReturn(version ?? 'v1.2.3');
+    when(notifier.onBattery).thenReturn(onBattery ?? false);
     return notifier;
   }
 

--- a/test/firmware_app_test.mocks.dart
+++ b/test/firmware_app_test.mocks.dart
@@ -122,6 +122,11 @@ class MockFwupdNotifier extends _i1.Mock implements _i6.FwupdNotifier {
         returnValue: '',
       ) as String);
   @override
+  bool get onBattery => (super.noSuchMethod(
+        Invocation.getter(#onBattery),
+        returnValue: false,
+      ) as bool);
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,

--- a/test/fwupd_notifier_test.dart
+++ b/test/fwupd_notifier_test.dart
@@ -23,6 +23,9 @@ void main() {
 
     when(service.daemonVersion).thenReturn('foo');
     expect(notifier.version, 'foo');
+
+    when(service.onBattery).thenReturn(true);
+    expect(notifier.onBattery, true);
   });
 
   test('notifies property changes', () async {

--- a/test/fwupd_service_test.dart
+++ b/test/fwupd_service_test.dart
@@ -20,6 +20,7 @@ void main() {
     final session = MockUbuntuSession();
     when(client.propertiesChanged).thenAnswer((_) => const Stream.empty());
     final upower = MockUPowerClient();
+    when(upower.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final service = FwupdService(
       fwupd: client,
@@ -66,6 +67,7 @@ void main() {
 
     final session = MockUbuntuSession();
     final upower = MockUPowerClient();
+    when(upower.propertiesChanged).thenAnswer((_) => const Stream.empty());
     final service = FwupdService(
       fwupd: fwupd,
       dio: dio,

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -42,6 +42,7 @@ MockFwupdService mockService({
   when(service.deviceChanged).thenAnswer((_) => const Stream.empty());
   when(service.deviceRemoved).thenAnswer((_) => const Stream.empty());
   when(service.propertiesChanged).thenAnswer((_) => const Stream.empty());
+  when(service.onBattery).thenAnswer((_) => false);
   return service;
 }
 


### PR DESCRIPTION
Another WIP. Adds a closable warning message when running on battery power.
- add `ErrorBanner` widget
- access upower's `onBattery` through `FwupdNotifier`
I've abused the existing `_propertiesChanged` controller to send upower's changed properties alongside those of fwupd - is this a terrible idea?
There's also still a small bug that might be of more general interest: when the UI renders before `FwupdService.init()` finishes a default `onBattery` state of `false` is reported, even if that's not the case. So we should somehow avoid this race condition and make sure all DBus properties of all services are set before trying to read them.

![battery](https://user-images.githubusercontent.com/113362648/195143540-c1364d00-5170-477a-b9cc-7bf81debd8a9.png)
