### PR TITLE
Fwupd workarounds

### DIFF
--- a/lib/detail_page.dart
+++ b/lib/detail_page.dart
@@ -19,6 +19,7 @@ class DetailPage extends StatefulWidget {
     required FwupdDevice device,
   }) {
     return ChangeNotifierProvider<DeviceModel>(
+      key: ValueKey(device.hashCode),
       create: (_) => DeviceModel(device, getService<FwupdService>()),
       child: const DetailPage(),
     );

--- a/lib/device_model.dart
+++ b/lib/device_model.dart
@@ -71,6 +71,7 @@ class DeviceModel extends SafeChangeNotifier {
 
   Future<void> install(FwupdRelease release) async {
     try {
+      state = DeviceState.busy;
       await _service.install(device, release);
       state = device.flags.contains(FwupdDeviceFlag.needsReboot)
           ? DeviceState.needsReboot

--- a/lib/device_tile.dart
+++ b/lib/device_tile.dart
@@ -17,6 +17,7 @@ class DeviceTile extends StatefulWidget {
     required FwupdDevice device,
   }) {
     return ChangeNotifierProvider<DeviceModel>(
+      key: ValueKey(device.hashCode),
       create: (_) => DeviceModel(device, getService<FwupdService>()),
       child: const DeviceTile(),
     );

--- a/lib/fwupd_notifier.dart
+++ b/lib/fwupd_notifier.dart
@@ -38,6 +38,8 @@ class FwupdNotifier extends SafeChangeNotifier {
     });
   }
 
+  Future<void> refresh() => _service.refreshProperties();
+
   @override
   Future<void> dispose() async {
     await _propertiesChanged?.cancel();

--- a/lib/fwupd_service.dart
+++ b/lib/fwupd_service.dart
@@ -63,6 +63,8 @@ class FwupdService {
     return _fwupd.close();
   }
 
+  Future<void> refreshProperties() => _fwupd.refreshPropertyCache();
+
   Future<File> _fetchRelease(FwupdRelease release) async {
     final remote = await _fwupd.getRemotes().then((remotes) {
       return remotes.firstWhere((remote) => remote.id == release.remoteId);

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -6,6 +6,7 @@ import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'device_model.dart';
+import 'device_store.dart';
 import 'fwupd_notifier.dart';
 import 'fwupd_x.dart';
 import 'src/widgets/confirmation_dialog.dart';
@@ -84,10 +85,11 @@ class ReleasePage extends StatelessWidget {
                             actionText: action,
                             onConfirm: () async {
                               final notifier = context.read<FwupdNotifier>();
+                              final store = context.read<DeviceStore>();
                               model.selectedRelease = null;
-                              model.state = DeviceState.busy;
                               await model.install(selected);
                               await notifier.refresh();
+                              await store.refresh();
                             },
                             onCancel: () {},
                           );

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -89,6 +89,12 @@ class ReleasePage extends StatelessWidget {
                               model.selectedRelease = null;
                               await model.install(selected);
                               await notifier.refresh();
+
+                              // refresh [DeviceStore] to force updates of all
+                              // [DeviceModel]s even if fwupd didn't send an
+                              // appropriate DBus signal (possible bug in 1.7.5
+                              // on Ubuntu 22.04)
+                              // TODO: improve when better solution is found
                               await store.refresh();
                             },
                             onCancel: () {},

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -6,6 +6,7 @@ import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'device_model.dart';
+import 'fwupd_notifier.dart';
 import 'fwupd_x.dart';
 import 'src/widgets/confirmation_dialog.dart';
 import 'src/widgets/release_card.dart';
@@ -82,9 +83,11 @@ class ReleasePage extends StatelessWidget {
                             message: dialogDesc,
                             actionText: action,
                             onConfirm: () async {
+                              final notifier = context.read<FwupdNotifier>();
                               model.selectedRelease = null;
                               model.state = DeviceState.busy;
                               await model.install(selected);
+                              await notifier.refresh();
                             },
                             onCancel: () {},
                           );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,10 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   freezed_annotation: ^2.1.0
-  fwupd: ^0.2.0
+  fwupd:
+    git:
+      url: https://github.com/d-loose/fwupd.dart
+      ref: refresh-property-cache
   handy_window: ^0.1.2
   meta: ^1.7.0
   path: ^1.8.0

--- a/test/firmware_app_test.mocks.dart
+++ b/test/firmware_app_test.mocks.dart
@@ -141,6 +141,15 @@ class MockFwupdNotifier extends _i1.Mock implements _i6.FwupdNotifier {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
+  _i4.Future<void> refresh() => (super.noSuchMethod(
+        Invocation.method(
+          #refresh,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
   _i4.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,

--- a/test/fwupd_service_test.mocks.dart
+++ b/test/fwupd_service_test.mocks.dart
@@ -884,6 +884,15 @@ class MockFwupdClient extends _i1.Mock implements _i11.FwupdClient {
         returnValueForMissingStub: _i9.Future<void>.value(),
       ) as _i9.Future<void>);
   @override
+  _i9.Future<void> refreshPropertyCache() => (super.noSuchMethod(
+        Invocation.method(
+          #refreshPropertyCache,
+          [],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+  @override
   _i9.Future<List<_i12.FwupdDevice>> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -88,6 +88,15 @@ class MockFwupdService extends _i1.Mock implements _i2.FwupdService {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
+  _i4.Future<void> refreshProperties() => (super.noSuchMethod(
+        Invocation.method(
+          #refreshProperties,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
   _i4.Future<void> activate(_i3.FwupdDevice? device) => (super.noSuchMethod(
         Invocation.method(
           #activate,


### PR DESCRIPTION
Workarounds for some issues with fwupd 1.7.5 in ubuntu 22.04:
- `FwupdClient` doesn't return to `FwupdStatus.idle` after installing a release but remains in `FwupdStatus.unknown`. The underlying property on DBus is changed, but no corresponding signal is sent.
Fix: force `FwupdClient` to re-read all DBus properties and update its cache (using [this fork](https://github.com/d-loose/fwupd.dart/tree/refresh-property-cache)).
- fwupd doesn't always send correct `DeviceChanged` signals after installing a release.
Fix: call `DeviceStore.refresh()` after install (maybe this is overkill?)