### PR TITLE
Portrait layout

### DIFF
--- a/lib/detail_page.dart
+++ b/lib/detail_page.dart
@@ -39,6 +39,7 @@ class _DetailPageState extends State<DetailPage> {
   @override
   Widget build(BuildContext context) {
     final deviceModel = context.watch<DeviceModel>();
+    final navigator = Navigator.of(context);
     return ClipRect(
       child: Theme(
         data: Theme.of(context).copyWith(
@@ -46,8 +47,8 @@ class _DetailPageState extends State<DetailPage> {
         ),
         child: Navigator(
           pages: [
-            const MaterialPage(
-              child: DevicePage(),
+            MaterialPage(
+              child: DevicePage(parentNavigator: navigator),
             ),
             if (deviceModel.selectedRelease != null)
               const MaterialPage(

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -54,6 +54,9 @@ class ReleasePage extends StatelessWidget {
         : YaruDetailPage(
             appBar: AppBar(
               title: Text('${device.name} ${device.version}'),
+              leading: Navigator.of(context).canPop()
+                  ? const YaruBackButton()
+                  : null,
             ),
             body: ListView(
               padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -48,7 +48,7 @@ static void my_application_activate(GApplication* application) {
   }
 
   GdkGeometry geometry;
-  geometry.min_width = 800;
+  geometry.min_width = 400;
   geometry.min_height = 700;
   gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
   gtk_window_set_default_size(window, 1280, 720);

--- a/test/firmware_app_test.dart
+++ b/test/firmware_app_test.dart
@@ -16,6 +16,23 @@ import 'test_utils.dart';
 
 @GenerateMocks([DeviceStore])
 void main() {
+  final devices = [
+    testDevice(
+      id: '1',
+      name: 'Device 1',
+      summary: 'Summary 1',
+      guid: [
+        '123e4567-e89b-12d3-a456-426614174000',
+        'a4f0aa5e-fdde-44d7-966c-40bd49385cc5',
+      ],
+      vendor: 'test vendor',
+      version: '1.0.0',
+      versionLowest: '0.0.1',
+      flags: {FwupdDeviceFlag.updatable, FwupdDeviceFlag.needsReboot},
+    ),
+    testDevice(id: '2', name: 'Device 2', summary: 'Summary 2'),
+  ];
+
   DeviceStore mockStore({
     required List<FwupdDevice> devices,
   }) {
@@ -35,6 +52,14 @@ void main() {
     );
   }
 
+  void expectDevicePropertyList(WidgetTester tester) {
+    expect(find.text(tester.lang.fwupdDeviceFlagNeedsReboot), findsOneWidget);
+    expect(find.text(devices.first.guid[1]), findsOneWidget);
+    expect(find.text(devices.first.vendor!), findsOneWidget);
+    expect(find.text(devices.first.version!), findsOneWidget);
+    expect(find.text(devices.first.versionLowest!), findsOneWidget);
+  }
+
   testWidgets('loading', (tester) async {
     final store = mockStore(devices: []);
     await tester
@@ -43,49 +68,48 @@ void main() {
     expect(find.byType(YaruCircularProgressIndicator), findsOneWidget);
   });
 
-  testWidgets('data', (tester) async {
-    registerMockService<FwupdService>(mockService());
+  group('data', () {
+    testWidgets('landscape layout', (tester) async {
+      registerMockService<FwupdService>(mockService());
 
-    final devices = [
-      testDevice(
-        id: '1',
-        name: 'Device 1',
-        summary: 'Summary 1',
-        guid: [
-          '123e4567-e89b-12d3-a456-426614174000',
-          'a4f0aa5e-fdde-44d7-966c-40bd49385cc5',
-        ],
-        vendor: 'test vendor',
-        version: '1.0.0',
-        versionLowest: '0.0.1',
-        flags: {FwupdDeviceFlag.updatable, FwupdDeviceFlag.needsReboot},
-      ),
-      testDevice(id: '2', name: 'Device 2', summary: 'Summary 2'),
-    ];
-    final store = mockStore(devices: devices);
-    await tester
-        .pumpApp((_) => buildPage(store: store, notifier: mockNotifier()));
+      final store = mockStore(devices: devices);
+      await tester
+          .pumpApp((_) => buildPage(store: store, notifier: mockNotifier()));
 
-    // First device appears twice in master detail layout
-    expect(find.text('Device 1'), findsNWidgets(2));
-    expect(find.text('Summary 1'), findsNWidgets(2));
-    expect(find.text(tester.lang.fwupdDeviceFlagNeedsReboot), findsOneWidget);
-    expect(find.text(devices.first.guid[1]), findsOneWidget);
-    expect(find.text(devices.first.vendor!), findsOneWidget);
-    expect(find.text(devices.first.version!), findsOneWidget);
-    expect(find.text(devices.first.versionLowest!), findsOneWidget);
+      expect(find.text(devices.first.name), findsNWidgets(2));
+      expect(find.text(devices.first.summary!), findsNWidgets(2));
+      expectDevicePropertyList(tester);
 
-    expect(find.text('Device 2'), findsOneWidget);
-    expect(find.text('Summary 2'), findsOneWidget);
+      expect(find.text(devices[1].name), findsOneWidget);
+      expect(find.text(devices[1].summary!), findsOneWidget);
+    });
+
+    testWidgets('portrait layout', (tester) async {
+      registerMockService<FwupdService>(mockService());
+
+      final store = mockStore(devices: devices);
+      await tester.pumpApp(
+          (_) => buildPage(store: store, notifier: mockNotifier()),
+          size: const Size(400, 850));
+
+      expect(find.text(devices.first.name), findsOneWidget);
+      expect(find.text(devices.first.summary!), findsOneWidget);
+      expect(find.text(devices[1].name), findsOneWidget);
+      expect(find.text(devices[1].summary!), findsOneWidget);
+      expect(find.text(tester.lang.currentVersion), findsNothing);
+
+      await tester.tap(find.text(devices.first.name));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(YaruBackButton), findsOneWidget);
+      expectDevicePropertyList(tester);
+    });
   });
 
   testWidgets('on battery', (tester) async {
     registerMockService<FwupdService>(mockService());
 
-    final store = mockStore(devices: [
-      testDevice(id: '1', name: 'Device 1', summary: 'Summary 1'),
-      testDevice(id: '2', name: 'Device 2', summary: 'Summary 2'),
-    ]);
+    final store = mockStore(devices: devices);
     await tester.pumpApp((_) =>
         buildPage(store: store, notifier: mockNotifier(onBattery: true)));
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -85,9 +85,10 @@ extension WidgetTesterX on WidgetTester {
     return Theme.of(widget);
   }
 
-  Future<void> pumpApp(WidgetBuilder builder) {
+  Future<void> pumpApp(WidgetBuilder builder,
+      {Size size = const Size(700, 850)}) {
     binding.window.devicePixelRatioTestValue = 1;
-    binding.window.physicalSizeTestValue = const Size(700, 850);
+    binding.window.physicalSizeTestValue = size;
     return pumpWidget(MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       home: Builder(builder: builder),


### PR DESCRIPTION
- allow `YaruMasterDetailPage` to collapse into portrait layout
- add `YaruBackButton` to navigate back to tile in portrait layout
- also use `YaruBackButton` instead of the default material button in `ReleasePage`

Please let me know if there's a better way to handle the nested navigators - currently I'm passing the portrait layout's navigator as a parameter to `DevicePage`, which is wrapped in a navigator itself to show the `ReleasePage`.

Somehow Ubuntu's screen recorder has been acting weird these days, so some screenshots will have to do:
![Screenshot from 2022-10-17 15-37-24](https://user-images.githubusercontent.com/113362648/196191751-bf70973e-c5bc-4496-8695-998fe10e4c14.png)
![Screenshot from 2022-10-17 15-37-10](https://user-images.githubusercontent.com/113362648/196191738-bbd31e56-e8dd-4c78-b1d8-2dcb1f4ffcdc.png)
![Screenshot from 2022-10-17 15-37-17](https://user-images.githubusercontent.com/113362648/196191745-6e365efc-0042-40ed-bc2f-e84fdf400859.png)
![Screenshot from 2022-10-17 15-37-35](https://user-images.githubusercontent.com/113362648/196191756-09addb5c-31a0-49d1-8e31-31ecfcfbf86b.png)
![Screenshot from 2022-10-17 15-37-54](https://user-images.githubusercontent.com/113362648/196191760-a3b65305-2702-4e4f-8f85-85412a348e54.png)


