### PR TITLE
Improve test coverage

### DIFF
--- a/lib/device_model.dart
+++ b/lib/device_model.dart
@@ -59,7 +59,7 @@ class DeviceModel extends SafeChangeNotifier {
   bool get onBattery => _service.onBattery;
 
   Future<List<FwupdRelease>> _fetchReleases() {
-    return _service.getReleases(_device.id).catchError(
+    return _service.getReleases(_device).catchError(
           (_) => <FwupdRelease>[],
           test: (e) =>
               e is FwupdNothingToDoException || e is FwupdNotSupportedException,

--- a/lib/fwupd_service.dart
+++ b/lib/fwupd_service.dart
@@ -126,20 +126,20 @@ class FwupdService {
 
   Future<List<FwupdDevice>> getDevices() => _fwupd.getDevices();
 
-  Future<List<FwupdRelease>> getDowngrades(String deviceId) {
-    return _fwupd.getDowngrades(deviceId);
+  Future<List<FwupdRelease>> getDowngrades(FwupdDevice device) {
+    return _fwupd.getDowngrades(device.id);
   }
 
   Future<List<FwupdPlugin>> getPlugins() => _fwupd.getPlugins();
 
-  Future<List<FwupdRelease>> getReleases(String deviceId) {
-    return _fwupd.getReleases(deviceId);
+  Future<List<FwupdRelease>> getReleases(FwupdDevice device) {
+    return _fwupd.getReleases(device.id);
   }
 
   Future<List<FwupdRemote>> getRemotes() => _fwupd.getRemotes();
 
-  Future<List<FwupdRelease>> getUpgrades(String deviceId) {
-    return _fwupd.getUpgrades(deviceId);
+  Future<List<FwupdRelease>> getUpgrades(FwupdDevice device) {
+    return _fwupd.getUpgrades(device.id);
   }
 
   Future<void> install(

--- a/test/device_model_test.dart
+++ b/test/device_model_test.dart
@@ -71,4 +71,34 @@ void main() {
     await deviceModel.verify();
     verify(service.verify(device)).called(1);
   });
+
+  test('verifyUpdate', () async {
+    final device = testDevice(id: 'a');
+
+    final service = mockService();
+
+    final deviceModel = DeviceModel(device, service);
+    await deviceModel.verifyUpdate();
+    verify(service.verifyUpdate(device)).called(1);
+  });
+
+  test('reboot', () async {
+    final device = testDevice(id: 'a');
+
+    final service = mockService();
+
+    final deviceModel = DeviceModel(device, service);
+    await deviceModel.reboot();
+    verify(service.reboot()).called(1);
+  });
+
+  test('onBattery', () async {
+    final device = testDevice(id: 'a');
+
+    final service = mockService();
+    when(service.onBattery).thenReturn(true);
+
+    final deviceModel = DeviceModel(device, service);
+    expect(deviceModel.onBattery, true);
+  });
 }

--- a/test/fwupd_notifier_test.dart
+++ b/test/fwupd_notifier_test.dart
@@ -32,6 +32,7 @@ void main() {
     final service = mockService();
     when(service.status).thenReturn(FwupdStatus.loading);
     when(service.percentage).thenReturn(75);
+    when(service.onBattery).thenReturn(true);
 
     final notifier = FwupdNotifier(service);
     expect(notifier.status, FwupdStatus.loading);
@@ -52,6 +53,9 @@ void main() {
 
     propertiesChanged.add(['Percentage']);
     expect(wasNotified, 2);
+
+    propertiesChanged.add(['OnBattery']);
+    expect(wasNotified, 3);
   });
 
   test('cancels subscriptions', () async {
@@ -68,5 +72,17 @@ void main() {
     await notifier.dispose();
 
     expect(propertiesChanged.hasListener, isFalse);
+  });
+
+  test('refresh', () async {
+    final service = mockService();
+    final notifier = FwupdNotifier(service);
+
+    await notifier.init();
+    await notifier.refresh();
+
+    verify(service.refreshProperties()).called(1);
+
+    await notifier.dispose();
   });
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -44,8 +44,8 @@ MockFwupdService mockService({
   final service = MockFwupdService();
   when(service.getDevices()).thenAnswer((_) async => devices ?? []);
   when(service.getReleases(any)).thenAnswer((i) async {
-    final id = i.positionalArguments[0];
-    final value = releases?[id];
+    final device = i.positionalArguments[0] as FwupdDevice;
+    final value = releases?[device.deviceId];
     if (value == null) throw const FwupdNothingToDoException();
     return value;
   });

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -126,11 +126,11 @@ class MockFwupdService extends _i1.Mock implements _i2.FwupdService {
             _i4.Future<List<_i3.FwupdDevice>>.value(<_i3.FwupdDevice>[]),
       ) as _i4.Future<List<_i3.FwupdDevice>>);
   @override
-  _i4.Future<List<_i3.FwupdRelease>> getDowngrades(String? deviceId) =>
+  _i4.Future<List<_i3.FwupdRelease>> getDowngrades(_i3.FwupdDevice? device) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDowngrades,
-          [deviceId],
+          [device],
         ),
         returnValue:
             _i4.Future<List<_i3.FwupdRelease>>.value(<_i3.FwupdRelease>[]),
@@ -145,11 +145,11 @@ class MockFwupdService extends _i1.Mock implements _i2.FwupdService {
             _i4.Future<List<_i3.FwupdPlugin>>.value(<_i3.FwupdPlugin>[]),
       ) as _i4.Future<List<_i3.FwupdPlugin>>);
   @override
-  _i4.Future<List<_i3.FwupdRelease>> getReleases(String? deviceId) =>
+  _i4.Future<List<_i3.FwupdRelease>> getReleases(_i3.FwupdDevice? device) =>
       (super.noSuchMethod(
         Invocation.method(
           #getReleases,
-          [deviceId],
+          [device],
         ),
         returnValue:
             _i4.Future<List<_i3.FwupdRelease>>.value(<_i3.FwupdRelease>[]),
@@ -164,11 +164,11 @@ class MockFwupdService extends _i1.Mock implements _i2.FwupdService {
             _i4.Future<List<_i3.FwupdRemote>>.value(<_i3.FwupdRemote>[]),
       ) as _i4.Future<List<_i3.FwupdRemote>>);
   @override
-  _i4.Future<List<_i3.FwupdRelease>> getUpgrades(String? deviceId) =>
+  _i4.Future<List<_i3.FwupdRelease>> getUpgrades(_i3.FwupdDevice? device) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUpgrades,
-          [deviceId],
+          [device],
         ),
         returnValue:
             _i4.Future<List<_i3.FwupdRelease>>.value(<_i3.FwupdRelease>[]),


### PR DESCRIPTION
I've added a few missing tests for `FwupdNotifier`, `FwupdService` and `DeviceModel`.
`FwupdService` now consistently uses `FwupdDevice`s as parameters (some methods used `String deviceId`)