### PR TITLE
improve progress indicators

### DIFF
--- a/lib/src/widgets/status_banner.dart
+++ b/lib/src/widgets/status_banner.dart
@@ -17,21 +17,25 @@ class StatusBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     return Visibility(
       visible: visible,
-      child: Column(
-        children: [
-          LinearProgressIndicator(value: progress),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              Text(message, style: Theme.of(context).textTheme.caption),
-              const SizedBox(width: 8.0),
-              const SizedBox(
-                height: 24,
-                child: YaruCircularProgressIndicator(),
-              ),
-            ],
-          ),
-        ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        child: Column(
+          children: [
+            YaruLinearProgressIndicator(value: progress),
+            const SizedBox(height: 8.0),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                Text(message, style: Theme.of(context).textTheme.caption),
+                const SizedBox(width: 8.0),
+                const SizedBox(
+                  height: 24,
+                  child: YaruCircularProgressIndicator(strokeWidth: 3),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/test/widgets/status_banner_test.dart
+++ b/test/widgets/status_banner_test.dart
@@ -15,9 +15,10 @@ void main() {
       ),
     ));
 
-    final indicator = find.byType(LinearProgressIndicator);
+    final indicator = find.byType(YaruLinearProgressIndicator);
     expect(indicator, findsOneWidget);
-    expect(tester.widget<LinearProgressIndicator>(indicator).value, progress);
+    expect(
+        tester.widget<YaruLinearProgressIndicator>(indicator).value, progress);
     expect(find.text(message), findsOneWidget);
     expect(find.byType(YaruCircularProgressIndicator), findsOneWidget);
   });


### PR DESCRIPTION
Minor UI updates:

- reduce stroke width of `YaruCircularProgressIndicator` as suggested by @Feichtmeier 
- use `YaruLinearProgressIndicator` instead of `LinearProgressIndicator`
- add padding

| | Dark| Light |
| - | - | - |
Before | ![Screenshot from 2022-10-18 17-23-26](https://user-images.githubusercontent.com/113362648/196473732-8ef893a6-f03b-4d7a-bd14-f26c4853bbd8.png) | ![Screenshot from 2022-10-18 17-23-34](https://user-images.githubusercontent.com/113362648/196473777-ad705bdc-eae8-4326-8a96-b9e8df7473cc.png) |
After | ![Screenshot from 2022-10-18 17-17-08](https://user-images.githubusercontent.com/113362648/196472694-263463dd-4a31-4f7f-9bbe-d6fb136f4943.png) | ![Screenshot from 2022-10-18 17-17-19](https://user-images.githubusercontent.com/113362648/196472793-a81c30dc-7c95-41e1-8c78-e0c631ea97f7.png) |

