### PR TITLE
Improve error handling

### DIFF
--- a/lib/device_model.dart
+++ b/lib/device_model.dart
@@ -13,15 +13,6 @@ class DeviceModel extends SafeChangeNotifier {
   FwupdDevice _device;
   List<FwupdRelease>? _releases;
   StreamSubscription? _sub;
-  FwupdException? _error;
-  FwupdException? get error => _error;
-
-  var _state = DeviceState.idle;
-  DeviceState get state => _state;
-  set state(DeviceState state) {
-    _state = state;
-    notifyListeners();
-  }
 
   Future<void> init() async {
     _sub =
@@ -34,8 +25,6 @@ class DeviceModel extends SafeChangeNotifier {
     await _sub?.cancel();
     super.dispose();
   }
-
-  Future<void> reboot() => _service.reboot();
 
   Future<void> update(FwupdDevice device) async {
     _device = device;
@@ -69,26 +58,8 @@ class DeviceModel extends SafeChangeNotifier {
   Future<void> verify() => _service.verify(_device);
   Future<void> verifyUpdate() => _service.verifyUpdate(_device);
 
-  Future<void> install(FwupdRelease release) async {
-    try {
-      state = DeviceState.busy;
-      await _service.install(device, release);
-      state = device.flags.contains(FwupdDeviceFlag.needsReboot)
-          ? DeviceState.needsReboot
-          : state = DeviceState.idle;
-    } on FwupdException catch (error) {
-      log.error('installation failed $error');
-      state = DeviceState.error;
-      _error = error;
-    }
-  }
+  Future<void> install(FwupdRelease release) =>
+      _service.install(device, release);
 
   bool hasUpgrade() => _releases?.any((r) => r.isUpgrade) == true;
-}
-
-enum DeviceState {
-  idle,
-  busy,
-  error,
-  needsReboot,
 }

--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -64,26 +64,6 @@ class DevicePage extends StatelessWidget {
       for (final flag in device.flags) flag.localize(context)
     ].whereNotNull();
 
-    if (model.state == DeviceState.needsReboot) {
-      WidgetsBinding.instance.addPostFrameCallback(
-        (_) => showConfirmationDialog(
-          context,
-          title: l10n.rebootConfirm,
-          actionText: l10n.reboot,
-          onCancel: () => model.state = DeviceState.idle,
-          onConfirm: model.reboot,
-        ),
-      );
-    } else if (model.state == DeviceState.error) {
-      WidgetsBinding.instance.addPostFrameCallback(
-        (_) => showErrorDialog(
-          context,
-          title: l10n.installError,
-          message: model.error!.localize(context),
-          onClose: () => model.state = DeviceState.idle,
-        ),
-      );
-    }
     return YaruDetailPage(
       appBar: AppBar(
         title: _buildAppBarTitle(context, device.name, device.summary),

--- a/lib/firmware_app.dart
+++ b/lib/firmware_app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:fwupd/fwupd.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -7,6 +8,7 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import 'detail_page.dart';
 import 'device_store.dart';
 import 'device_tile.dart';
+import 'fwupd_l10n.dart';
 import 'fwupd_notifier.dart';
 import 'fwupd_service.dart';
 import 'widgets.dart';
@@ -35,6 +37,27 @@ class _FirmwareAppState extends State<FirmwareApp> {
     super.initState();
     context.read<DeviceStore>().init();
     context.read<FwupdNotifier>().init();
+    getService<FwupdService>()
+      ..registerErrorListener(_showError)
+      ..registerConfirmationListener(_getConfirmation);
+  }
+
+  void _showError(FwupdException e) {
+    showErrorDialog(
+      context,
+      title: AppLocalizations.of(context).installError,
+      message: e.localize(context),
+    );
+  }
+
+  Future<bool> _getConfirmation() async {
+    final response = await showConfirmationDialog(
+      context,
+      title: AppLocalizations.of(context).rebootConfirm,
+      actionText: AppLocalizations.of(context).reboot,
+    );
+
+    return response == DialogAction.action;
   }
 
   @override

--- a/lib/firmware_app.dart
+++ b/lib/firmware_app.dart
@@ -42,11 +42,11 @@ class _FirmwareAppState extends State<FirmwareApp> {
       ..registerConfirmationListener(_getConfirmation);
   }
 
-  void _showError(FwupdException e) {
+  void _showError(Exception e) {
     showErrorDialog(
       context,
       title: AppLocalizations.of(context).installError,
-      message: e.localize(context),
+      message: e is FwupdException ? e.localize(context) : e.toString(),
     );
   }
 

--- a/lib/fwupd_service.dart
+++ b/lib/fwupd_service.dart
@@ -50,6 +50,18 @@ class FwupdService {
   Stream<FwupdDevice> get deviceRemoved => _fwupd.deviceRemoved;
   Stream<List<String>> get propertiesChanged => _propertiesChanged.stream;
 
+  Function(FwupdException)? _errorListener;
+  Future<bool> Function()? _confirmationListener;
+
+  void registerErrorListener(Function(FwupdException e) errorListener) {
+    _errorListener = errorListener;
+  }
+
+  void registerConfirmationListener(
+      Future<bool> Function() confirmationListener) {
+    _confirmationListener = confirmationListener;
+  }
+
   Future<void> init() async {
     await _fwupd.connect();
     _fwupdPropertiesSubscription ??=
@@ -152,15 +164,23 @@ class FwupdService {
     log.debug('on $device');
     final file = await _fetchRelease(release);
     resourceHandleFromFile ??= ResourceHandle.fromFile;
-    return _fwupd.install(
-      device.id,
-      resourceHandleFromFile(file.openSync()),
-      flags: {
-        if (release.isDowngrade) FwupdInstallFlag.allowOlder,
-        if (!release.isDowngrade && !release.isUpgrade)
-          FwupdInstallFlag.allowReinstall,
-      },
-    );
+    try {
+      await _fwupd.install(
+        device.id,
+        resourceHandleFromFile(file.openSync()),
+        flags: {
+          if (release.isDowngrade) FwupdInstallFlag.allowOlder,
+          if (!release.isDowngrade && !release.isUpgrade)
+            FwupdInstallFlag.allowReinstall,
+        },
+      );
+      if (device.flags.contains(FwupdDeviceFlag.needsReboot)) {
+        if (await _confirmationListener?.call() == true) await reboot();
+      }
+    } on FwupdException catch (e) {
+      _errorListener?.call(e);
+      if (_errorListener == null) rethrow;
+    }
   }
 
   bool get onBattery => _upower.onBattery;

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -49,64 +49,60 @@ class ReleasePage extends StatelessWidget {
       );
     }
 
-    return model.state == DeviceState.busy
-        ? const Center(child: YaruCircularProgressIndicator())
-        : YaruDetailPage(
-            appBar: AppBar(
-              title: Text('${device.name} ${device.version}'),
-              leading: Navigator.of(context).canPop()
-                  ? const YaruBackButton()
-                  : null,
-            ),
-            body: ListView(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              children: releases
-                  .map(
-                    (release) => ReleaseCard(
-                      release: release,
-                      selected: release == selected,
-                      onSelected: () =>
-                          context.read<DeviceModel>().selectedRelease = release,
-                    ),
-                  )
-                  .toList(),
-            ),
-            bottomNavigationBar: ButtonBar(
-              children: [
-                ElevatedButton(
-                  onPressed: selected != null
-                      ? () {
-                          showConfirmationDialog(
-                            context,
-                            title: dialogText,
-                            message: dialogDesc,
-                            actionText: action,
-                            onConfirm: () async {
-                              final notifier = context.read<FwupdNotifier>();
-                              final store = context.read<DeviceStore>();
-                              model.selectedRelease = null;
-                              await model.install(selected);
-                              await notifier.refresh();
+    return YaruDetailPage(
+      appBar: AppBar(
+        title: Text('${device.name} ${device.version}'),
+        leading: Navigator.of(context).canPop() ? const YaruBackButton() : null,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        children: releases
+            .map(
+              (release) => ReleaseCard(
+                release: release,
+                selected: release == selected,
+                onSelected: () =>
+                    context.read<DeviceModel>().selectedRelease = release,
+              ),
+            )
+            .toList(),
+      ),
+      bottomNavigationBar: ButtonBar(
+        children: [
+          ElevatedButton(
+            onPressed: selected != null
+                ? () {
+                    showConfirmationDialog(
+                      context,
+                      title: dialogText,
+                      message: dialogDesc,
+                      actionText: action,
+                      onConfirm: () async {
+                        final notifier = context.read<FwupdNotifier>();
+                        final store = context.read<DeviceStore>();
+                        model.selectedRelease = null;
+                        await model.install(selected);
+                        await notifier.refresh();
 
-                              // refresh [DeviceStore] to force updates of all
-                              // [DeviceModel]s even if fwupd didn't send an
-                              // appropriate DBus signal (possible bug in 1.7.5
-                              // on Ubuntu 22.04)
-                              // TODO: improve when better solution is found
-                              await store.refresh();
-                            },
-                            onCancel: () {},
-                          );
-                        }
-                      : null,
-                  child: Text(action),
-                ),
-                OutlinedButton(
-                  onPressed: Navigator.of(context).pop,
-                  child: Text(l10n.cancel),
-                )
-              ],
-            ),
-          );
+                        // refresh [DeviceStore] to force updates of all
+                        // [DeviceModel]s even if fwupd didn't send an
+                        // appropriate DBus signal (possible bug in 1.7.5
+                        // on Ubuntu 22.04)
+                        // TODO: improve when better solution is found
+                        await store.refresh();
+                      },
+                      onCancel: () {},
+                    );
+                  }
+                : null,
+            child: Text(action),
+          ),
+          OutlinedButton(
+            onPressed: Navigator.of(context).pop,
+            child: Text(l10n.cancel),
+          )
+        ],
+      ),
+    );
   }
 }

--- a/lib/src/widgets/confirmation_dialog.dart
+++ b/lib/src/widgets/confirmation_dialog.dart
@@ -92,7 +92,7 @@ Future<DialogAction?> showConfirmationDialog(
       actionText: actionText,
       icon: const Icon(YaruIcons.question, size: 64.0),
       onCancel: onCancel ?? () {},
-      onAction: onConfirm,
+      onAction: onConfirm ?? () {},
       closeable: false,
     );
 

--- a/test/device_model_test.dart
+++ b/test/device_model_test.dart
@@ -22,44 +22,15 @@ void main() {
     expect(deviceModel.releases, releases);
   });
 
-  group('install releases', () {
-    test('successful', () async {
-      final device = testDevice(id: 'a');
-      final release = FwupdRelease(name: '');
+  test('install', () async {
+    final device = testDevice(id: 'a');
+    final release = FwupdRelease(name: '');
 
-      final service = mockService();
+    final service = mockService();
 
-      final deviceModel = DeviceModel(device, service);
-      await deviceModel.install(release);
-      verify(service.install(device, release)).called(1);
-      expect(deviceModel.state, DeviceState.idle);
-    });
-
-    test('needs reboot', () async {
-      final device = testDevice(id: 'a', flags: {FwupdDeviceFlag.needsReboot});
-      final release = FwupdRelease(name: '');
-
-      final service = mockService();
-
-      final deviceModel = DeviceModel(device, service);
-      await deviceModel.install(release);
-      verify(service.install(device, release)).called(1);
-      expect(deviceModel.state, DeviceState.needsReboot);
-    });
-    test('install error', () async {
-      final device = testDevice(id: 'a');
-      final release = FwupdRelease(name: '');
-
-      final service = mockService();
-      when(service.install(device, release))
-          .thenThrow(const FwupdAuthFailedException());
-
-      final deviceModel = DeviceModel(device, service);
-      await deviceModel.install(release);
-      verify(service.install(device, release)).called(1);
-      expect(deviceModel.state, DeviceState.error);
-      expect(deviceModel.error, const FwupdAuthFailedException());
-    });
+    final deviceModel = DeviceModel(device, service);
+    await deviceModel.install(release);
+    verify(service.install(device, release)).called(1);
   });
 
   test('verify', () async {
@@ -80,16 +51,6 @@ void main() {
     final deviceModel = DeviceModel(device, service);
     await deviceModel.verifyUpdate();
     verify(service.verifyUpdate(device)).called(1);
-  });
-
-  test('reboot', () async {
-    final device = testDevice(id: 'a');
-
-    final service = mockService();
-
-    final deviceModel = DeviceModel(device, service);
-    await deviceModel.reboot();
-    verify(service.reboot()).called(1);
   });
 
   test('onBattery', () async {

--- a/test/device_page_test.dart
+++ b/test/device_page_test.dart
@@ -17,15 +17,12 @@ void main() {
     required FwupdDevice device,
     bool? hasUpgrade,
     List<FwupdRelease>? releases,
-    DeviceState? state,
     FwupdException? error,
   }) {
     final model = MockDeviceModel();
     when(model.device).thenReturn(device);
     when(model.hasUpgrade()).thenReturn(hasUpgrade ?? false);
     when(model.releases).thenReturn(releases ?? []);
-    when(model.state).thenReturn(state ?? DeviceState.idle);
-    when(model.error).thenReturn(error);
     return model;
   }
 
@@ -138,54 +135,5 @@ void main() {
       await tester.tap(find.text(tester.lang.ok));
       verify(model.verify()).called(1);
     });
-  });
-
-  group('needs reboot', () {
-    testWidgets('do reboot', (tester) async {
-      final device = testDevice(id: 'a');
-      final model = mockModel(device: device, state: DeviceState.needsReboot);
-      final notifier = mockNotifier();
-      await tester.pumpApp((_) => buildPage(model: model, notifier: notifier));
-      await tester.pumpAndSettle();
-
-      expect(find.text(tester.lang.rebootConfirm), findsOneWidget);
-      expect(find.text(tester.lang.reboot), findsOneWidget);
-      expect(find.text(tester.lang.cancel), findsOneWidget);
-
-      await tester.tap(find.text(tester.lang.reboot));
-      verify(model.reboot()).called(1);
-    });
-
-    testWidgets('cancel reboot', (tester) async {
-      final device = testDevice(id: 'a');
-      final model = mockModel(device: device, state: DeviceState.needsReboot);
-      final notifier = mockNotifier();
-      await tester.pumpApp((_) => buildPage(model: model, notifier: notifier));
-      await tester.pumpAndSettle();
-
-      expect(find.text(tester.lang.rebootConfirm), findsOneWidget);
-      expect(find.text(tester.lang.reboot), findsOneWidget);
-      expect(find.text(tester.lang.cancel), findsOneWidget);
-
-      await tester.tap(find.text(tester.lang.cancel));
-      verify(model.state = DeviceState.idle).called(1);
-      verifyNever(model.reboot());
-    });
-  });
-
-  testWidgets('error', (tester) async {
-    final device = testDevice(id: 'a');
-    const error = FwupdWriteException();
-    final model =
-        mockModel(device: device, state: DeviceState.error, error: error);
-    final notifier = mockNotifier();
-    await tester.pumpApp((_) => buildPage(model: model, notifier: notifier));
-    await tester.pumpAndSettle();
-
-    expect(find.text(tester.lang.installError), findsOneWidget);
-    expect(find.text(tester.lang.close), findsOneWidget);
-
-    await tester.tap(find.text(tester.lang.close));
-    verify(model.state = DeviceState.idle).called(1);
   });
 }

--- a/test/device_page_test.mocks.dart
+++ b/test/device_page_test.mocks.dart
@@ -40,19 +40,6 @@ class MockDeviceModel extends _i1.Mock implements _i3.DeviceModel {
   }
 
   @override
-  _i3.DeviceState get state => (super.noSuchMethod(
-        Invocation.getter(#state),
-        returnValue: _i3.DeviceState.idle,
-      ) as _i3.DeviceState);
-  @override
-  set state(_i3.DeviceState? state) => super.noSuchMethod(
-        Invocation.setter(
-          #state,
-          state,
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
   set selectedRelease(_i2.FwupdRelease? release) => super.noSuchMethod(
         Invocation.setter(
           #selectedRelease,

--- a/test/device_page_test.mocks.dart
+++ b/test/device_page_test.mocks.dart
@@ -89,15 +89,6 @@ class MockDeviceModel extends _i1.Mock implements _i3.DeviceModel {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
-  _i4.Future<void> reboot() => (super.noSuchMethod(
-        Invocation.method(
-          #reboot,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
   _i4.Future<void> update(_i2.FwupdDevice? device) => (super.noSuchMethod(
         Invocation.method(
           #update,

--- a/test/firmware_app_test.dart
+++ b/test/firmware_app_test.dart
@@ -61,6 +61,7 @@ void main() {
   }
 
   testWidgets('loading', (tester) async {
+    registerMockService<FwupdService>(mockService());
     final store = mockStore(devices: []);
     await tester
         .pumpApp((_) => buildPage(store: store, notifier: mockNotifier()));

--- a/test/fwupd_service_test.dart
+++ b/test/fwupd_service_test.dart
@@ -90,6 +90,7 @@ void main() {
       verify(dio.download(url, file.path,
               onReceiveProgress: anyNamed('onReceiveProgress')))
           .called(1);
+      verifyNever(service.reboot());
     });
 
     test('error', () async {
@@ -101,6 +102,19 @@ void main() {
       service.registerErrorListener(
           expectAsync1((e) => expect(e, isInstanceOf<DioError>())));
       await service.install(device, release, (f) => MockResourceHandle());
+      verifyNever(service.reboot());
+    });
+
+    test('reboot', () async {
+      service
+          .registerConfirmationListener(expectAsync0(() => Future.value(true)));
+      await service.install(
+          testDevice(
+              id: 'b',
+              flags: {FwupdDeviceFlag.updatable, FwupdDeviceFlag.needsReboot}),
+          release,
+          (f) => MockResourceHandle());
+      verify(service.reboot()).called(1);
     });
   });
 

--- a/test/fwupd_service_test.dart
+++ b/test/fwupd_service_test.dart
@@ -39,26 +39,11 @@ void main() {
     verify(upower.close()).called(1);
   });
 
-  test('download', () async {
+  group('download', () {
     const url = 'http://test.fake/myrelease.cab';
 
     final fs = MemoryFileSystem.test();
     final file = fs.file('${fs.systemTempDirectory.path}/myrelease.cab');
-    file.createSync(recursive: true);
-    expect(file.existsSync(), isTrue);
-
-    final dio = MockDio();
-    when(dio.download(url, file.path,
-            onReceiveProgress: anyNamed('onReceiveProgress')))
-        .thenAnswer((i) async {
-      i.namedArguments[#onReceiveProgress]!(0, 1);
-      return Response(requestOptions: RequestOptions(path: file.path));
-    });
-
-    final fwupd = MockFwupdClient();
-    when(fwupd.propertiesChanged).thenAnswer((_) => const Stream.empty());
-    when(fwupd.getRemotes()).thenAnswer((_) async =>
-        [FwupdRemote(id: 'myremote', kind: FwupdRemoteKind.download)]);
 
     final device = testDevice(id: 'mydevice');
     final release = FwupdRelease(
@@ -67,9 +52,11 @@ void main() {
       locations: const [url],
     );
 
+    final dio = MockDio();
+    final fwupd = MockFwupdClient();
     final session = MockUbuntuSession();
     final upower = MockUPowerClient();
-    when(upower.propertiesChanged).thenAnswer((_) => const Stream.empty());
+
     final service = FwupdService(
       fwupd: fwupd,
       dio: dio,
@@ -77,13 +64,44 @@ void main() {
       session: session,
       upower: upower,
     );
-    await service.init();
 
-    await service.install(device, release, (f) => MockResourceHandle());
+    setUp(() async {
+      file.createSync(recursive: true);
+      expect(file.existsSync(), isTrue);
 
-    verify(dio.download(url, file.path,
-            onReceiveProgress: anyNamed('onReceiveProgress')))
-        .called(1);
+      when(dio.download(url, file.path,
+              onReceiveProgress: anyNamed('onReceiveProgress')))
+          .thenAnswer((i) async {
+        i.namedArguments[#onReceiveProgress]!(0, 1);
+        return Response(requestOptions: RequestOptions(path: file.path));
+      });
+
+      when(fwupd.propertiesChanged).thenAnswer((_) => const Stream.empty());
+      when(fwupd.getRemotes()).thenAnswer((_) async =>
+          [FwupdRemote(id: release.remoteId!, kind: FwupdRemoteKind.download)]);
+
+      when(upower.propertiesChanged).thenAnswer((_) => const Stream.empty());
+
+      await service.init();
+    });
+    test('success', () async {
+      await service.install(device, release, (f) => MockResourceHandle());
+
+      verify(dio.download(url, file.path,
+              onReceiveProgress: anyNamed('onReceiveProgress')))
+          .called(1);
+    });
+
+    test('error', () async {
+      when(dio.download(url, file.path,
+              onReceiveProgress: anyNamed('onReceiveProgress')))
+          .thenThrow(DioError(
+              requestOptions: RequestOptions(path: url), error: 'dio error'));
+
+      service.registerErrorListener(
+          expectAsync1((e) => expect(e, isInstanceOf<DioError>())));
+      await service.install(device, release, (f) => MockResourceHandle());
+    });
   });
 
   test('fwupd methods', () async {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -73,17 +73,9 @@ FwupdNotifier mockNotifier({
 }
 
 extension WidgetTesterX on WidgetTester {
-  static Type context = Scaffold;
-
-  AppLocalizations get lang {
-    final widget = element(find.byType(context).first);
-    return AppLocalizations.of(widget);
-  }
-
-  ThemeData get theme {
-    final widget = element(find.byType(context).first);
-    return Theme.of(widget);
-  }
+  BuildContext get context => element(find.byType(Scaffold).first);
+  AppLocalizations get lang => AppLocalizations.of(context);
+  ThemeData get theme => Theme.of(context);
 
   Future<void> pumpApp(WidgetBuilder builder,
       {Size size = const Size(700, 850)}) {

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -72,8 +72,7 @@ class MockFwupdService extends _i1.Mock implements _i2.FwupdService {
         returnValue: false,
       ) as bool);
   @override
-  void registerErrorListener(
-          dynamic Function(_i3.FwupdException)? errorListener) =>
+  void registerErrorListener(dynamic Function(Exception)? errorListener) =>
       super.noSuchMethod(
         Invocation.method(
           #registerErrorListener,

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -72,6 +72,26 @@ class MockFwupdService extends _i1.Mock implements _i2.FwupdService {
         returnValue: false,
       ) as bool);
   @override
+  void registerErrorListener(
+          dynamic Function(_i3.FwupdException)? errorListener) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #registerErrorListener,
+          [errorListener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void registerConfirmationListener(
+          _i4.Future<bool> Function()? confirmationListener) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #registerConfirmationListener,
+          [confirmationListener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   _i4.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,

--- a/test/widgets/message_dialog_test.dart
+++ b/test/widgets/message_dialog_test.dart
@@ -60,6 +60,35 @@ void main() {
     expect(completer.isCompleted, isTrue);
   });
 
+  testWidgets('cancel confirmation dialog', (tester) async {
+    const title = 'title';
+    const message = 'message';
+    final completer = Completer<void>();
+    await tester.pumpApp((context) => Scaffold(
+          body: OutlinedButton(
+            onPressed: () => showConfirmationDialog(
+              context,
+              title: title,
+              message: message,
+              onCancel: completer.complete,
+            ),
+            child: const Text('click me'),
+          ),
+        ));
+    await tester.tap(find.text('click me'));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(YaruIcons.question), findsOneWidget);
+    expect(find.text(title), findsOneWidget);
+    expect(find.text(message), findsOneWidget);
+
+    expect(find.text(tester.lang.ok), findsOneWidget);
+    final cancelButton = find.text(tester.lang.cancel);
+    expect(cancelButton, findsOneWidget);
+
+    await tester.tap(cancelButton);
+    expect(completer.isCompleted, isTrue);
+  });
+
   testWidgets('error dialog', (tester) async {
     const title = 'title';
     const message = 'message';


### PR DESCRIPTION
I've removed the error handling from the `DeviceModel` and moved it directly to `FwupdService`. There are now two callbacks to display errors and get user confirmations that are called on `FwupdExceptions` during `install()` and before invoking `reboot()`, respectively. `FirmwareApp` then shows the dialogs through these callbacks.

~~Still WIP - need to add remaining tests.~~
