### PR TITLE
Use GtkApplicationNotifier.commandLine

### DIFF
--- a/integration_test/firmware_updater_test.dart
+++ b/integration_test/firmware_updater_test.dart
@@ -28,7 +28,7 @@ void main() {
       expect(upgrade, isNotNull, reason: 'Fake webcam has no upgrades');
       expect(upgrade!.version, isNotEmpty);
 
-      await app.main();
+      await app.main([]);
       await tester.pumpAndSettle();
 
       await tester.pumpAndTapDeviceHeader('Fake webcam');
@@ -60,7 +60,7 @@ void main() {
       expect(reinstall, isNotNull, reason: 'Fake webcam has no reinstall');
       expect(reinstall!.version, isNotEmpty);
 
-      await app.main();
+      await app.main([]);
       await tester.pumpAndSettle();
 
       await tester.pumpAndTapDeviceHeader('Fake webcam');
@@ -89,7 +89,7 @@ void main() {
       expect(downgrade, isNotNull, reason: 'Fake webcam has no downgrades');
       expect(downgrade!.version, isNotEmpty);
 
-      await app.main();
+      await app.main([]);
       await tester.pumpAndSettle();
 
       await tester.pumpAndTapDeviceHeader('Fake webcam');
@@ -116,7 +116,7 @@ void main() {
       expect(webcam!.checksum, isNull,
           reason: 'Fake webcam already has a checksum');
 
-      await app.main();
+      await app.main([]);
       await tester.pumpAndSettle();
 
       await tester.pumpAndTapDeviceHeader('Fake webcam');

--- a/lib/firmware_app.dart
+++ b/lib/firmware_app.dart
@@ -35,7 +35,6 @@ class FirmwareApp extends StatefulWidget {
 
 class _FirmwareAppState extends State<FirmwareApp> {
   final _controller = ValueNotifier<int>(-1);
-  late final Future _storeInitialized;
 
   @override
   void initState() {
@@ -49,7 +48,7 @@ class _FirmwareAppState extends State<FirmwareApp> {
       ..registerErrorListener(_showError)
       ..registerConfirmationListener(_getConfirmation)
       ..registerDeviceRequestListener(_showRequest);
-    _storeInitialized = store.init();
+    store.init().then((_) => _commandLineListener(gtkNotifier.commandLine!));
     gtkNotifier.addCommandLineListener(_commandLineListener);
   }
 
@@ -60,9 +59,8 @@ class _FirmwareAppState extends State<FirmwareApp> {
     super.dispose();
   }
 
-  Future<void> _commandLineListener(List<String> args) async {
+  void _commandLineListener(List<String> args) {
     final store = context.read<DeviceStore>();
-    await _storeInitialized;
     _controller.value = store.indexOf(args.firstOrNull);
     store.showReleases = args.isNotEmpty;
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:yaru/yaru.dart';
 import 'firmware_app.dart';
 import 'fwupd_service.dart';
 
-Future<void> main() async {
+Future<void> main(List<String> args) async {
   Logger.setup(level: LogLevel.fromString(kDebugMode ? 'debug' : 'info'));
 
   registerService<FwupdService>(
@@ -17,7 +17,7 @@ Future<void> main() async {
     dispose: (s) => s.dispose(),
   );
 
-  registerService<GtkApplicationNotifier>(GtkApplicationNotifier.new,
+  registerService<GtkApplicationNotifier>(() => GtkApplicationNotifier(args),
       dispose: (s) => s.dispose());
 
   runApp(YaruTheme(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     git:
       url: https://github.com/d-loose/fwupd.dart
       ref: refresh-property-cache
-  gtk_application: ^0.0.2
+  gtk_application: ^0.0.3
   handy_window: ^0.1.2
   meta: ^1.7.0
   path: ^1.8.0


### PR DESCRIPTION
gtk_application.dart won't be able to deliver local command-line arguments but the new property was added to help with passing the arguments around so that the handling of local vs. remote command-line arguments can be easily unified.