### PR TITLE
call 'CommandLine' DBus method to invoke firmware-updater from the notifier

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -74,25 +74,18 @@ static void my_application_activate(GApplication* application) {
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }
 
-// Implements GApplication::local_command_line.
-static gboolean my_application_local_command_line(GApplication* application,
-                                                  gchar*** arguments,
-                                                  int* exit_status) {
-  MyApplication* self = MY_APPLICATION(application);
-  // Strip out the first argument as it is the binary name.
-  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+static gint my_application_command_line(GApplication *application, GApplicationCommandLine *command_line) {
+  MyApplication *self = MY_APPLICATION(application);
+  gchar **arguments = g_application_command_line_get_arguments(command_line, nullptr);
+  self->dart_entrypoint_arguments = g_strdupv(arguments + 1);
 
   g_autoptr(GError) error = nullptr;
   if (!g_application_register(application, nullptr, &error)) {
     g_warning("Failed to register: %s", error->message);
-    *exit_status = 1;
-    return TRUE;
+    return 1;
   }
-
   g_application_activate(application);
-  *exit_status = 0;
-
-  return FALSE;
+  return 0;
 }
 
 // Implements GObject::dispose.
@@ -104,8 +97,7 @@ static void my_application_dispose(GObject* object) {
 
 static void my_application_class_init(MyApplicationClass* klass) {
   G_APPLICATION_CLASS(klass)->activate = my_application_activate;
-  G_APPLICATION_CLASS(klass)->local_command_line =
-      my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->command_line = my_application_command_line;
   G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
 }
 

--- a/packages/firmware_notifier/bin/firmware_notifier.dart
+++ b/packages/firmware_notifier/bin/firmware_notifier.dart
@@ -18,7 +18,7 @@ void main(List<String> arguments) async {
       values: [
         DBusObjectPath('/com/canonical/firmware_updater'),
         DBusArray(
-          DBusSignature.array(DBusSignature('y')),
+          DBusSignature.array(DBusSignature.byte),
           [
             DBusArray.byte([0]),
             for (final arg in args) DBusArray.byte(arg.runes.followedBy([0])),
@@ -26,7 +26,7 @@ void main(List<String> arguments) async {
         ),
         DBusDict.stringVariant({}),
       ],
-      replySignature: DBusSignature('i'),
+      replySignature: DBusSignature.int32,
     );
     await dbusClient.close();
   });

--- a/packages/firmware_notifier/bin/firmware_notifier.dart
+++ b/packages/firmware_notifier/bin/firmware_notifier.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:dbus/dbus.dart';
 import 'package:desktop_notifications/desktop_notifications.dart';
 import 'package:firmware_notifier/firmware_notifier.dart';
 
@@ -10,8 +9,26 @@ void main(List<String> arguments) async {
 
   notifications.map((n) => n.action).forEach((action) async {
     final args = (await action).split(', ');
-    await Process.start('firmware-updater', args,
-        mode: ProcessStartMode.detached);
+    final dbusClient = DBusClient.session();
+    await dbusClient.callMethod(
+      path: DBusObjectPath('/com/canonical/firmware_updater'),
+      interface: 'org.gtk.Application',
+      destination: 'com.canonical.firmware_updater',
+      name: 'CommandLine',
+      values: [
+        DBusObjectPath('/com/canonical/firmware_updater'),
+        DBusArray(
+          DBusSignature.array(DBusSignature('y')),
+          [
+            DBusArray.byte([0]),
+            for (final arg in args) DBusArray.byte(arg.runes.followedBy([0])),
+          ],
+        ),
+        DBusDict.stringVariant({}),
+      ],
+      replySignature: DBusSignature('i'),
+    );
+    await dbusClient.close();
   });
 
   await Future.wait(notifications.map((n) => n.closeReason));

--- a/packages/firmware_notifier/pubspec.yaml
+++ b/packages/firmware_notifier/pubspec.yaml
@@ -11,6 +11,7 @@ dev_dependencies:
 
 dependencies:
   collection: ^1.17.0
+  dbus: ^0.7.8
   desktop_notifications: ^0.6.3
   fwupd: ^0.2.2
   meta: ^1.8.0


### PR DESCRIPTION
- override `command_line` instead of `local_command_line` in my_application.cc to preserve default command line handler for DBus signals (i.e. correct behavior on --gapplication-service).