### PR TITLE
CI: run snap build as cron

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,15 +22,3 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
     - run: melos pub-get
     - run: melos build
-
-  snap:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: snapcore/action-build@v1
-      id: snapcraft
-    - uses: actions/upload-artifact@v3
-      if: github.event_name == 'workflow_dispatch'
-      with:
-        name: 'snap'
-        path: ${{steps.snapcraft.outputs.snap}}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,19 @@
+name: Snap
+
+on:
+  schedule:
+  - cron:  '45 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: snapcore/action-build@v1
+      id: snapcraft
+    - uses: actions/upload-artifact@v3
+      if: github.event_name == 'workflow_dispatch'
+      with:
+        name: 'snap'
+        path: ${{steps.snapcraft.outputs.snap}}


### PR DESCRIPTION
speed up PR workflow by moving snap build to a daily cron job