### PR TITLE
DBus activation in the snap

### DIFF
--- a/launcher-script/bin/launch-firmware-updater.sh
+++ b/launcher-script/bin/launch-firmware-updater.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+gapplication launch com.canonical.firmware_updater "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ architectures:
   - build-on: amd64
 
 slots:
-  dbus:
+  dbus-slot:
     interface: dbus
     name: com.canonical.firmware_updater
     bus: session
@@ -38,7 +38,7 @@ parts:
       - zip
     override-prime: ''
 
-  firmware-updater:
+  firmware-updater-app:
     after: [ flutter-git ]
     plugin: nil
     source: .
@@ -63,10 +63,21 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/bin/
       dart compile exe bin/firmware_notifier.dart -o $CRAFT_PART_INSTALL/bin/firmware-notifier
 
+  firmware-updater:
+    plugin: dump
+    source: ./launcher-script/
+
 apps:
   firmware-updater:
-    command: bin/firmware-updater
+    command: bin/launch-firmware-updater.sh
     desktop: bin/data/flutter_assets/assets/firmware-updater.desktop
+    extensions: [gnome]
+
+  firmware-updater-app:
+    command: bin/firmware-updater
+    daemon: dbus
+    daemon-scope: user
+    activates-on: [dbus-slot]
     extensions: [gnome]
     plugs:
       - fwupd


### PR DESCRIPTION
uses a helper script to launch the desktop application, which currently needs to be a user daemon to work with DBus activation in the snap, see #120 