### PR TITLE
rename localization placeholders

### DIFF
--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -29,7 +29,7 @@ class DevicePage extends StatelessWidget {
       Text(
         text,
         textAlign: TextAlign.end,
-        style: Theme.of(context).textTheme.caption,
+        style: Theme.of(context).textTheme.bodySmall,
       ),
     );
   }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -7,7 +7,7 @@
   "deviceUnavailable": "The device will be unavailable during this action.",
   "deviceRequest": "Device request",
   "downgrade": "Downgrade",
-  "downgradeConfirm": "Downgrade {name} from version {current} to {selected}?",
+  "downgradeConfirm": "Downgrade {name} from version {current} to {version2}?",
   "@downgradeConfirm": {
     "placeholders": {
       "name": {
@@ -16,7 +16,7 @@
       "current": {
         "type": "String?"
       },
-      "selected": {
+      "version2": {
         "type": "String?"
       }
     }
@@ -121,7 +121,7 @@
   },
   "updateChecksumsInfo": "This will record the current cryptographic hashes as verified.",
   "upgrade": "Upgrade",
-  "upgradeConfirm": "Upgrade {name} from version {current} to {selected}?",
+  "upgradeConfirm": "Upgrade {name} from version {current} to {version2}?",
   "@upgradeConfirm": {
     "placeholders": {
       "name": {
@@ -130,7 +130,7 @@
       "current": {
         "type": "String?"
       },
-      "selected": {
+      "version2": {
         "type": "String?"
       }
     }

--- a/lib/src/widgets/small_chip.dart
+++ b/lib/src/widgets/small_chip.dart
@@ -18,7 +18,7 @@ class SmallChip extends StatelessWidget {
         style: const TextStyle(color: Colors.white),
       ),
       labelPadding: const EdgeInsets.symmetric(horizontal: 4),
-      labelStyle: Theme.of(context).textTheme.caption!.copyWith(fontSize: 10),
+      labelStyle: Theme.of(context).textTheme.bodySmall!.copyWith(fontSize: 10),
       backgroundColor: color ??
           Theme.of(context).disabledColor.withOpacity(
               Theme.of(context).brightness == Brightness.light ? 0.4 : 0.1),

--- a/lib/src/widgets/status_banner.dart
+++ b/lib/src/widgets/status_banner.dart
@@ -23,7 +23,7 @@ class StatusBanner extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              Text(message, style: Theme.of(context).textTheme.caption),
+              Text(message, style: Theme.of(context).textTheme.bodySmall),
               const SizedBox(width: 8.0),
               const SizedBox(
                 height: 24,


### PR DESCRIPTION
due to new AppLocalization features in flutter 3.3.10 'selected' can't be used as a placeholder name any more

Edit: flutter 3.3.10 also complains about deprecation of `TextTheme.caption`