### PR TITLE
Handle empty device list gracefully

### DIFF
--- a/lib/firmware_app.dart
+++ b/lib/firmware_app.dart
@@ -118,7 +118,10 @@ class _FirmwareAppState extends State<FirmwareApp> {
                   DetailPage.create(context, device: store.devices[index]),
               tileBuilder: (context, index, selected) =>
                   DeviceTile.create(context, device: store.devices[index]),
-              emptyBuilder: (_) => Center(child: Text(l10n.noDevicesFound)),
+              emptyBuilder: (_) => Scaffold(
+                appBar: YaruWindowTitleBar(title: Text(l10n.appTitle)),
+                body: Center(child: Text(l10n.noDevicesFound)),
+              ),
             ),
           )
         : const Center(child: YaruCircularProgressIndicator());

--- a/lib/firmware_app.dart
+++ b/lib/firmware_app.dart
@@ -118,6 +118,7 @@ class _FirmwareAppState extends State<FirmwareApp> {
                   DetailPage.create(context, device: store.devices[index]),
               tileBuilder: (context, index, selected) =>
                   DeviceTile.create(context, device: store.devices[index]),
+              emptyBuilder: (_) => Center(child: Text(l10n.noDevicesFound)),
             ),
           )
         : const Center(child: YaruCircularProgressIndicator());

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -91,6 +91,7 @@
   "fwupdStatusShutdown": "The daemon is shutting down",
   "guid": "GUIDs",
   "installError": "Failed to install firmware!",
+  "noDevicesFound": "No devices found",
   "ok": "OK",
   "reboot": "Reboot",
   "rebootConfirm": "The update requires a reboot to complete. Do you want to reboot now?",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   yaru: ^0.6.0
   yaru_colors: ^0.1.0
   yaru_icons: ^1.0.0
-  yaru_widgets: ^2.0.0
+  yaru_widgets: ^2.3.1
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/test/firmware_app_test.dart
+++ b/test/firmware_app_test.dart
@@ -122,6 +122,18 @@ void main() {
       expect(find.byType(YaruBackButton), findsOneWidget);
       expectDevicePropertyList(tester);
     });
+
+    testWidgets('empty list', (tester) async {
+      registerMockService<FwupdService>(mockService());
+      registerMockService<GtkApplicationNotifier>(mockGtkApplicationNotifier());
+
+      final store = mockStore(devices: []);
+      await tester
+          .pumpApp((_) => buildPage(store: store, notifier: mockNotifier()));
+      await tester.pumpAndSettle();
+
+      expect(find.text(tester.lang.noDevicesFound), findsOneWidget);
+    });
   });
 
   testWidgets('on battery', (tester) async {


### PR DESCRIPTION
Use new `emptyBuilder` in yaru_widgets to show a message rather than causing an exception.
This obviously needs some UI work :)
![image](https://user-images.githubusercontent.com/113362648/228839958-c6728d17-28d5-442e-83e8-ccebacbe5563.png)


Fix #161