### PR TITLE
feat(release_page): hide old versions in expandable

### DIFF
--- a/integration_test/firmware_updater_test.dart
+++ b/integration_test/firmware_updater_test.dart
@@ -9,6 +9,7 @@ import 'package:fwupd/fwupd.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
+import 'package:yaru_widgets/widgets.dart';
 
 import '../test/test_utils.dart';
 
@@ -93,6 +94,9 @@ void main() {
       expect(find.devicePage(downgrade.version), findsNothing);
 
       await tester.pumpAndTapButton(tester.lang.showReleases);
+      await tester.pumpAndSettle();
+
+      await tester.pumpAndTapExpandable();
       await tester.pumpAndSettle();
 
       await tester.pumpAndTapReleaseButton(downgrade.version);
@@ -240,6 +244,14 @@ extension IntegrationTester on WidgetTester {
     );
     await pumpUntil(button);
     return tap(button);
+  }
+
+  Future<void> pumpAndTapExpandable() async {
+    final expandable = find.descendant(
+        of: find.byType(YaruExpandable),
+        matching: find.text(lang.olderVersions));
+    await pumpUntil(expandable);
+    return tap(expandable);
   }
 }
 

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:fwupd/fwupd.dart';
 import 'package:provider/provider.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'device_model.dart';
 import 'device_store.dart';
 import 'fwupd_notifier.dart';
+import 'fwupd_x.dart';
 import 'src/widgets/release_card.dart';
 
 class ReleasePage extends StatelessWidget {
@@ -15,36 +18,56 @@ class ReleasePage extends StatelessWidget {
     final model = context.watch<DeviceModel>();
     final device = model.device;
     final releases = model.releases ?? [];
+    final currentReleases = releases.where((r) => !r.isDowngrade);
+    final oldReleases = releases.where((r) => r.isDowngrade);
+    final l10n = AppLocalizations.of(context);
+
+    Widget buildReleaseCard(FwupdRelease release) => ReleaseCard(
+          release: release,
+          device: device,
+          onInstall: () async {
+            final notifier = context.read<FwupdNotifier>();
+            final store = context.read<DeviceStore>();
+            store.showReleases = false;
+            await model.install(release);
+            await notifier.refresh();
+
+            // refresh [DeviceStore] to force updates of all
+            // [DeviceModel]s even if fwupd didn't send an
+            // appropriate DBus signal (possible bug in 1.7.5
+            // on Ubuntu 22.04)
+            // TODO: improve when better solution is found
+            await store.refresh();
+          },
+        );
 
     return YaruDetailPage(
       appBar: YaruWindowTitleBar(
         title: Text('${device.name} ${device.version}'),
         leading: Navigator.of(context).canPop() ? const YaruBackButton() : null,
       ),
-      body: ListView(
-        padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
-        children: releases
-            .map(
-              (release) => ReleaseCard(
-                release: release,
-                device: device,
-                onInstall: () async {
-                  final notifier = context.read<FwupdNotifier>();
-                  final store = context.read<DeviceStore>();
-                  store.showReleases = false;
-                  await model.install(release);
-                  await notifier.refresh();
-
-                  // refresh [DeviceStore] to force updates of all
-                  // [DeviceModel]s even if fwupd didn't send an
-                  // appropriate DBus signal (possible bug in 1.7.5
-                  // on Ubuntu 22.04)
-                  // TODO: improve when better solution is found
-                  await store.refresh();
-                },
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
+          child: Column(
+            children: [
+              Column(
+                children: currentReleases.map(buildReleaseCard).toList(),
               ),
-            )
-            .toList(),
+              if (oldReleases.isNotEmpty)
+                YaruExpandable(
+                  expandButtonPosition: YaruExpandableButtonPosition.start,
+                  header: Text(l10n.olderVersions),
+                  child: Column(
+                    children: oldReleases
+                        .where((release) => release.isDowngrade)
+                        .map(buildReleaseCard)
+                        .toList(),
+                  ),
+                ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/release_page.dart
+++ b/lib/release_page.dart
@@ -47,26 +47,22 @@ class ReleasePage extends StatelessWidget {
         leading: Navigator.of(context).canPop() ? const YaruBackButton() : null,
       ),
       body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
-          child: Column(
-            children: [
-              Column(
-                children: currentReleases.map(buildReleaseCard).toList(),
-              ),
-              if (oldReleases.isNotEmpty)
-                YaruExpandable(
-                  expandButtonPosition: YaruExpandableButtonPosition.start,
-                  header: Text(l10n.olderVersions),
-                  child: Column(
-                    children: oldReleases
-                        .where((release) => release.isDowngrade)
-                        .map(buildReleaseCard)
-                        .toList(),
-                  ),
+        padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
+        child: Column(
+          children: [
+            ...currentReleases.map(buildReleaseCard).toList(),
+            if (oldReleases.isNotEmpty)
+              YaruExpandable(
+                expandButtonPosition: YaruExpandableButtonPosition.start,
+                header: Text(l10n.olderVersions),
+                child: Column(
+                  children: oldReleases
+                      .where((release) => release.isDowngrade)
+                      .map(buildReleaseCard)
+                      .toList(),
                 ),
-            ],
-          ),
+              ),
+          ],
         ),
       ),
     );

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -93,6 +93,7 @@
   "installError": "Failed to install firmware!",
   "noDevicesFound": "No devices found",
   "ok": "OK",
+  "olderVersions": "Older Versions",
   "reboot": "Reboot",
   "rebootConfirm": "The update requires a reboot to complete. Do you want to reboot now?",
   "reinstall": "Reinstall",

--- a/test/release_page_test.dart
+++ b/test/release_page_test.dart
@@ -1,0 +1,66 @@
+import 'package:firmware_updater/device_model.dart';
+import 'package:firmware_updater/device_store.dart';
+import 'package:firmware_updater/fwupd_notifier.dart';
+import 'package:firmware_updater/release_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fwupd/fwupd.dart';
+import 'package:provider/provider.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  Widget buildPage({
+    required DeviceModel model,
+    required FwupdNotifier notifier,
+    required DeviceStore store,
+  }) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<DeviceModel>.value(value: model),
+        ChangeNotifierProvider<FwupdNotifier>.value(value: notifier),
+        ChangeNotifierProvider<DeviceStore>.value(value: store),
+      ],
+      child: const ReleasePage(),
+    );
+  }
+
+  testWidgets('dropdown', (tester) async {
+    final device = testDevice(id: 'a', version: '2');
+    final model = mockModel(device: device, releases: [
+      FwupdRelease(
+        name: 'new release',
+        flags: const {FwupdReleaseFlag.isUpgrade},
+        version: '3.0.0',
+      ),
+      FwupdRelease(
+        name: 'current release',
+        flags: const {FwupdReleaseFlag.isUpgrade},
+        version: '2.0.0',
+      ),
+      FwupdRelease(
+        name: 'old release',
+        flags: const {FwupdReleaseFlag.isDowngrade},
+        version: '1.0.0',
+      ),
+    ]);
+    final notifier = mockNotifier();
+    final store = mockStore();
+    await tester.pumpApp(
+        (_) => buildPage(model: model, notifier: notifier, store: store));
+
+    expect(find.text('3.0.0').hitTestable(), findsOneWidget);
+    expect(find.text('2.0.0').hitTestable(), findsOneWidget);
+    expect(find.text('1.0.0').hitTestable(), findsNothing);
+
+    final olderVersions = find.text(tester.lang.olderVersions);
+    expect(olderVersions, findsOneWidget);
+
+    await tester.tap(olderVersions);
+    await tester.pumpAndSettle();
+
+    expect(find.text('3.0.0').hitTestable(), findsOneWidget);
+    expect(find.text('2.0.0').hitTestable(), findsOneWidget);
+    expect(find.text('1.0.0').hitTestable(), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Ref #177 
UDENG-703

@elioqoshi I'm splitting the UI updates into small components so it's easier to iterate when necessary - please ignore everything besides the expandable in the screen cast :)

[Screencast from 2023-06-13 18-08-19.webm](https://github.com/canonical/firmware-updater/assets/113362648/32db1e5a-e313-49b5-9b69-142719cdb0ab)
