### PR TITLE
feat: use colored circle badge for updates

### DIFF
--- a/lib/src/widgets/device_header.dart
+++ b/lib/src/widgets/device_header.dart
@@ -1,11 +1,9 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'device_icon.dart';
-import 'small_chip.dart';
 
 class DeviceHeader extends StatelessWidget {
   const DeviceHeader({
@@ -19,22 +17,14 @@ class DeviceHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
     return YaruMasterTile(
       title: Text(device.name),
       subtitle: Text(device.summary ?? ''),
-      leading: Icon(DeviceIcon.fromName(device.icon.firstOrNull)),
-      trailing: hasUpgrade
-          ? SmallChip(
-              text: l10n.update,
-              color: Theme.of(context)
-                      .elevatedButtonTheme
-                      .style!
-                      .backgroundColor!
-                      .resolve({}) ??
-                  Theme.of(context).primaryColor,
-            )
-          : null,
+      leading: Badge(
+        isLabelVisible: hasUpgrade,
+        alignment: AlignmentDirectional.topStart,
+        child: Icon(DeviceIcon.fromName(device.icon.firstOrNull)),
+      ),
     );
   }
 }

--- a/lib/src/widgets/release_card.dart
+++ b/lib/src/widgets/release_card.dart
@@ -69,9 +69,15 @@ class ReleaseCard extends StatelessWidget {
       headline: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            release.version,
-            style: Theme.of(context).textTheme.headlineSmall,
+          Badge(
+            isLabelVisible: release.isUpgrade,
+            child: Padding(
+              padding: const EdgeInsetsDirectional.only(end: 8),
+              child: Text(
+                release.version,
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+            ),
           ),
           Visibility(
             visible: release.version == device.version,


### PR DESCRIPTION
Ref #177 
UDENG-703

@elioqoshi I'm using [material design's `Badge`](https://m3.material.io/components/badges/overview) here. By default it seems to be slightly smaller than what you have in your designs - what do you think?

![image](https://github.com/canonical/firmware-updater/assets/113362648/ece4eebd-bc6c-400d-a873-c35168aff5ac)
