### PR TITLE
Change the snapcraft grade to stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Firmware Updater
 description: Update Firmware
 confinement: strict
 base: core22
-grade: devel
+grade: stable
 license: GPL-3.0+
 icon: snap/local/firmware-updater.png
 architectures:


### PR DESCRIPTION
Which is a pre-required to be able to publish to stable