### PR TITLE
feat: updating the UIs

### DIFF
--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -79,38 +79,45 @@ class DevicePage extends StatelessWidget {
       {required BuildContext context, bool enabled = true}) {
     final model = context.read<DeviceModel>();
     final l10n = AppLocalizations.of(context);
-    return ButtonBar(
-      mainAxisSize: MainAxisSize.min,
-      alignment: MainAxisAlignment.start,
-      children: [
-        if (model.hasUpgrade)
-          ElevatedButton(
-            onPressed: enabled
-                ? () => showConfirmationDialog(
-                      context,
-                      title: l10n.updateConfirm(
-                        model.device.name,
-                        model.latestRelease?.version,
-                      ),
-                      message: model.device.flags
-                              .contains(FwupdDeviceFlag.usableDuringUpdate)
-                          ? null
-                          : l10n.deviceUnavailable,
-                      actionText: l10n.update,
-                      onConfirm: () => model.install(model.latestRelease!),
-                      onCancel: () {},
-                    )
-                : null,
-            child: Text(l10n.updateToLatest),
-          ),
-        if (model.releases?.isNotEmpty ?? false)
-          FilledButton(
-            onPressed: enabled
-                ? () => context.read<DeviceStore>().showReleases = true
-                : null,
-            child: Text(l10n.allVersions),
-          ),
-      ],
+    return Padding(
+      padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
+      child: ButtonBar(
+        mainAxisSize: MainAxisSize.min,
+        alignment: MainAxisAlignment.start,
+        buttonPadding: EdgeInsets.zero,
+        children: [
+          if (model.hasUpgrade)
+            Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: ElevatedButton(
+                onPressed: enabled
+                    ? () => showConfirmationDialog(
+                          context,
+                          title: l10n.updateConfirm(
+                            model.device.name,
+                            model.latestRelease?.version,
+                          ),
+                          message: model.device.flags
+                                  .contains(FwupdDeviceFlag.usableDuringUpdate)
+                              ? null
+                              : l10n.deviceUnavailable,
+                          actionText: l10n.update,
+                          onConfirm: () => model.install(model.latestRelease!),
+                          onCancel: () {},
+                        )
+                    : null,
+                child: Text(l10n.updateToLatest),
+              ),
+            ),
+          if (model.releases?.isNotEmpty ?? false)
+            FilledButton(
+              onPressed: enabled
+                  ? () => context.read<DeviceStore>().showReleases = true
+                  : null,
+              child: Text(l10n.allVersions),
+            ),
+        ],
+      ),
     );
   }
 

--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -166,6 +166,7 @@ class DevicePage extends StatelessWidget {
             ),
             const SizedBox(height: 32),
             Table(
+              defaultVerticalAlignment: TableCellVerticalAlignment.middle,
               columnWidths: const {
                 0: FlexColumnWidth(),
                 1: FixedColumnWidth(16),

--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -37,27 +37,42 @@ class DevicePage extends StatelessWidget {
 
   static Widget _buildLabel(BuildContext context, String text,
       [String? chipLabel]) {
-    return _buildPadding(chipLabel == null
-        ? Text(text)
-        : Row(
-            children: [
-              Text(text),
-              const SizedBox(width: 8),
-              Chip(
-                label: Text(chipLabel),
-                labelStyle: Theme.of(context)
-                    .textTheme
-                    .labelMedium
-                    ?.copyWith(color: Theme.of(context).colorScheme.secondary),
-                labelPadding: EdgeInsets.zero,
-                backgroundColor: Theme.of(context)
-                    .colorScheme
-                    .secondary
-                    .adjust(lightness: 0.64, saturation: 1),
-                side: BorderSide.none,
-              ),
-            ],
-          ));
+    final lightChipLabelColor = Theme.of(context).colorScheme.secondary;
+    final darkChipLabelColor = lightChipLabelColor.copyWith(lightness: .65);
+
+    final lightChipBackgroundColor = Theme.of(context)
+        .colorScheme
+        .secondary
+        .adjust(lightness: 0.64, saturation: 1);
+
+    final darkChipBackgroundColor =
+        lightChipBackgroundColor.copyWith(lightness: .4, alpha: 0.3);
+
+    return _buildPadding(
+      chipLabel == null
+          ? Text(text)
+          : Row(
+              children: [
+                Text(text),
+                const SizedBox(width: 8),
+                Chip(
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  label: Text(chipLabel),
+                  labelStyle: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      color: Theme.of(context).brightness == Brightness.light
+                          ? lightChipLabelColor
+                          : darkChipLabelColor),
+                  labelPadding: EdgeInsets.zero,
+                  visualDensity: const VisualDensity(vertical: -4),
+                  backgroundColor:
+                      Theme.of(context).brightness == Brightness.light
+                          ? lightChipBackgroundColor
+                          : darkChipBackgroundColor,
+                  side: BorderSide.none,
+                ),
+              ],
+            ),
+    );
   }
 
   static Widget _buildAppBarTitle(

--- a/lib/device_page.dart
+++ b/lib/device_page.dart
@@ -215,47 +215,54 @@ class DevicePage extends StatelessWidget {
                       DevicePage._buildPadding(Text(flag))
                     ]),
                 if (device.canVerify)
-                  TableRow(children: [
-                    DevicePage._buildHeader(context, l10n.checksum),
-                    const SizedBox.shrink(),
-                    ButtonBar(
-                      mainAxisSize: MainAxisSize.min,
-                      alignment: MainAxisAlignment.start,
-                      overflowButtonSpacing: 8.0,
-                      children: [
-                        OutlinedButton(
-                          onPressed: fwupdIdle
-                              ? () => showConfirmationDialog(
-                                    context,
-                                    title: l10n
-                                        .updateChecksumsConfirm(device.name),
-                                    message: l10n.updateChecksumsInfo,
-                                    onConfirm: model.verifyUpdate,
-                                    actionText: l10n.update,
-                                  )
-                              : null,
-                          child: Text(l10n.updateChecksums),
+                  TableRow(
+                    children: [
+                      DevicePage._buildHeader(context, l10n.checksum),
+                      const SizedBox.shrink(),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8),
+                        child: ButtonBar(
+                          mainAxisSize: MainAxisSize.min,
+                          alignment: MainAxisAlignment.start,
+                          overflowButtonSpacing: 8.0,
+                          buttonPadding: EdgeInsets.zero,
+                          children: [
+                            OutlinedButton(
+                              onPressed: fwupdIdle
+                                  ? () => showConfirmationDialog(
+                                        context,
+                                        title: l10n.updateChecksumsConfirm(
+                                            device.name),
+                                        message: l10n.updateChecksumsInfo,
+                                        onConfirm: model.verifyUpdate,
+                                        actionText: l10n.update,
+                                      )
+                                  : null,
+                              child: Text(l10n.updateChecksums),
+                            ),
+                            const SizedBox(width: 8),
+                            if (device.checksum != null)
+                              OutlinedButton(
+                                onPressed: fwupdIdle
+                                    ? () => showConfirmationDialog(
+                                          context,
+                                          title: l10n.verifyFirmwareConfirm(
+                                              device.name),
+                                          message: device.flags.contains(
+                                                  FwupdDeviceFlag
+                                                      .usableDuringUpdate)
+                                              ? null
+                                              : l10n.deviceUnavailable,
+                                          onConfirm: model.verify,
+                                        )
+                                    : null,
+                                child: Text(l10n.verifyFirmware),
+                              ),
+                          ],
                         ),
-                        if (device.checksum != null)
-                          OutlinedButton(
-                            onPressed: fwupdIdle
-                                ? () => showConfirmationDialog(
-                                      context,
-                                      title: l10n
-                                          .verifyFirmwareConfirm(device.name),
-                                      message: device.flags.contains(
-                                              FwupdDeviceFlag
-                                                  .usableDuringUpdate)
-                                          ? null
-                                          : l10n.deviceUnavailable,
-                                      onConfirm: model.verify,
-                                    )
-                                : null,
-                            child: Text(l10n.verifyFirmware),
-                          ),
-                      ],
-                    )
-                  ])
+                      ),
+                    ],
+                  )
               ],
             ),
           ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,15 +22,34 @@ Future<void> main(List<String> args) async {
 
   runApp(
     YaruTheme(
-      builder: (context, yaru, child) => MaterialApp(
-        debugShowCheckedModeBanner: false,
-        theme: yaru.theme,
-        darkTheme: yaru.darkTheme,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
-        routes: const {'/': FirmwareApp.create},
-      ),
+      builder: (context, yaru, child) {
+        final darkColorScheme = yaru.darkTheme?.colorScheme;
+        final lightColorScheme = yaru.theme?.colorScheme;
+
+        return MaterialApp(
+          debugShowCheckedModeBanner: false,
+          theme: createYaruLightTheme(
+            primaryColor: YaruColors.orange,
+            elevatedButtonColor: YaruColors.dark.success,
+          ).copyWith(
+            colorScheme: lightColorScheme?.copyWith(
+              secondary: YaruColors.dark.success,
+            ),
+          ),
+          darkTheme: createYaruDarkTheme(
+            primaryColor: YaruColors.orange,
+            elevatedButtonColor: YaruColors.dark.success,
+          ).copyWith(
+            colorScheme: darkColorScheme?.copyWith(
+              secondary: YaruColors.dark.success,
+            ),
+          ),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
+          routes: const {'/': FirmwareApp.create},
+        );
+      },
     ),
   );
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -114,7 +114,7 @@
   "update": "Update",
   "updateAvailable": "Update available",
   "updateChecksums": "Update Checksums",
-  "updateChecksumsConfirm": "Update device checksums of {name}?",
+  "updateChecksumsConfirm": "Update device checksums of <b>{name}</b>?",
   "@updateChecksumsConfirm": {
     "placeholders": {
       "name": {

--- a/lib/src/widgets/release_card.dart
+++ b/lib/src/widgets/release_card.dart
@@ -57,7 +57,7 @@ class ReleaseCard extends StatelessWidget {
         actionText: action,
         onConfirm: onInstall,
         onCancel: () {},
-        icon: YaruIcons.sync,
+        icon: YaruIcons.update_available,
       );
     }
 

--- a/test/device_page_test.dart
+++ b/test/device_page_test.dart
@@ -109,7 +109,7 @@ void main() {
       await tester.tap(find.text(tester.lang.updateChecksums));
       await tester.pumpAndSettle();
 
-      expect(find.text(tester.lang.updateChecksumsConfirm(device.name)),
+      expect(find.html(tester.lang.updateChecksumsConfirm(device.name)),
           findsOneWidget);
       expect(find.text(tester.lang.updateChecksumsInfo), findsOneWidget);
       expect(find.text(tester.lang.update), findsOneWidget);


### PR DESCRIPTION
In this PR:

- Updating the icon on the update firmware confirmation dialog
- Making the device name bold on the checksum confirmation dialog
- Overriding the Yaru theme to force the green accent theme.
- Removing some padding, so some content is align with the rest of the content on the device page.

Screenshots:

![Screenshot from 2023-11-23 16-04-50](https://github.com/canonical/firmware-updater/assets/20175372/31b616c4-8331-4560-a431-bb554e332d02)
![Screenshot from 2023-11-23 16-05-01](https://github.com/canonical/firmware-updater/assets/20175372/22367d81-0163-49c8-8655-1e1e34f48ab4)
![Screenshot from 2023-11-23 16-05-11](https://github.com/canonical/firmware-updater/assets/20175372/cc657aed-94aa-471e-80ee-dc97c70a6093)

