### PR TITLE
feat: switching to the right icon when updating firmware

### DIFF
--- a/packages/firmware_updater/lib/device_page.dart
+++ b/packages/firmware_updater/lib/device_page.dart
@@ -10,6 +10,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fwupd/fwupd.dart';
 import 'package:provider/provider.dart';
 import 'package:yaru/yaru.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class DevicePage extends StatelessWidget {
@@ -111,6 +112,7 @@ class DevicePage extends StatelessWidget {
                             model.device.name,
                             model.latestRelease?.version,
                           ),
+                          icon: YaruIcons.update_available,
                           message: model.device.flags
                                   .contains(FwupdDeviceFlag.usableDuringUpdate)
                               ? null


### PR DESCRIPTION
In this PR:

- Switching an icon when updating firmware. 


Before:
![image](https://github.com/canonical/firmware-updater/assets/20175372/d180beaa-270f-48f2-863c-49ba25cf0b51)


After:
![image](https://github.com/canonical/firmware-updater/assets/20175372/1fccb847-81e2-4819-9808-27c01e8e842c)

 