### PR TITLE
Generate an AlertDialog screen when A/C must be applied for some updates to proceed - this is issue #215.

### DIFF
--- a/packages/firmware_updater/lib/firmware_app.dart
+++ b/packages/firmware_updater/lib/firmware_app.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:collection/collection.dart';
 import 'package:firmware_updater/detail_page.dart';
 import 'package:firmware_updater/device_store.dart';
@@ -39,6 +40,7 @@ class FirmwareApp extends StatefulWidget {
 class _FirmwareAppState extends State<FirmwareApp> {
   YaruPageController? _controller;
   bool _initialized = false;
+  bool _onBattery = false;
 
   @override
   void initState() {
@@ -60,6 +62,36 @@ class _FirmwareAppState extends State<FirmwareApp> {
       });
     });
     gtkNotifier.addCommandLineListener(_commandLineListener);
+
+    Future.delayed(const Duration(seconds: 1), () async {
+      final l10n = AppLocalizations.of(context);
+      if (_onBattery) {
+        await _showAlertDialog(l10n.acPowerTitle, l10n.acPowerMustBeSupplied);
+      }
+    });
+  }
+
+  Future<dynamic> _showAlertDialog(String titleP, String contentP) {
+    return showDialog(
+      context: context,
+      builder: (context) {
+        final l10n = AppLocalizations.of(context);
+        // return object of type Dialog
+        return AlertDialog(
+          title: Text(titleP),
+          content: Text(contentP),
+          actions: <Widget>[
+            // usually buttons at the bottom of the dialog
+            TextButton(
+              child: Text(l10n.ok),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
@@ -109,12 +141,10 @@ class _FirmwareAppState extends State<FirmwareApp> {
   Widget build(BuildContext context) {
     final store = context.watch<DeviceStore>();
     final l10n = AppLocalizations.of(context);
+    _onBattery =
+        context.select<FwupdNotifier, bool>((notifier) => notifier.onBattery);
     return _initialized
-        ? ErrorBanner(
-            message: context.select<FwupdNotifier, bool>(
-                    (notifier) => notifier.onBattery)
-                ? l10n.batteryWarning
-                : null,
+        ? Center(
             child: YaruMasterDetailPage(
               appBar: YaruWindowTitleBar(title: Text(l10n.appTitle)),
               controller: _controller,

--- a/packages/firmware_updater/lib/src/l10n/app_en.arb
+++ b/packages/firmware_updater/lib/src/l10n/app_en.arb
@@ -147,5 +147,9 @@
   },
   "currentVersion": "Current Version",
   "minVersion": "Minimum Version",
-  "latestVersion": "Latest Version"
+  "latestVersion": "Latest Version",
+  "acPowerTitle": "You are currently on battery power",
+  "acPowerMustBeSupplied": "BIOS and other updates can't commence on battery power.\nPlug into A/C power and restart this app to perform those updates if available.",
+  "legacyBootTitle": "Legacy Boot Mode is selected in the BIOS",
+  "legacyBootCantUpdateInThisMode": "BIOS and other updates can't commence in this mode.\nSwitch to UEFI Boot Mode in the BIOS to proceed.\nNote - this may require an OS reinstall."
 }


### PR DESCRIPTION
Add an alert dialog that looks like this:

![image](https://github.com/canonical/firmware-updater/assets/22241543/1d61532e-635f-4127-ac86-2bfa076b8700)
