### PR TITLE
fix: handle errors when fwupd detects no devices

### DIFF
--- a/packages/firmware_notifier/lib/firmware_notifier.dart
+++ b/packages/firmware_notifier/lib/firmware_notifier.dart
@@ -8,7 +8,10 @@ Future<Map<FwupdDevice, FwupdRelease>> getUpdates(
   final fwupdClient = client ?? FwupdClient();
   await fwupdClient.connect();
 
-  final devices = await fwupdClient.getDevices();
+  final devices = await fwupdClient.getDevices().catchError(
+        (_) => Future.value(<FwupdDevice>[]),
+        test: (e) => e is FwupdNothingToDoException,
+      );
   final updates = {
     for (final device in devices)
       device: (await fwupdClient.getReleases(device.deviceId).catchError(

--- a/packages/firmware_notifier/test/firmware_notifier_test.dart
+++ b/packages/firmware_notifier/test/firmware_notifier_test.dart
@@ -57,4 +57,16 @@ void main() {
             body: anyNamed('body')))
         .called(2);
   });
+
+  test('no detected devices', () async {
+    final client = MockFwupdClient();
+    when(client.getDevices()).thenAnswer((_) async {
+      throw const FwupdNothingToDoException();
+      // ignore: dead_code
+      return []; // the mock needs the correct return type
+    });
+
+    final updates = await getUpdates(client);
+    expect(updates, isEmpty);
+  });
 }

--- a/packages/firmware_updater/lib/device_store.dart
+++ b/packages/firmware_updater/lib/device_store.dart
@@ -52,11 +52,16 @@ class DeviceStore extends SafeChangeNotifier {
   }
 
   Future<void> refresh() {
-    return _service.getDevices().then((devices) {
-      _devices = devices.where((device) => device.isUpdatable).toList();
-      log.debug('${_devices.length} devices');
-      notifyListeners();
-    });
+    return _service.getDevices().then(
+      (devices) {
+        _devices = devices.where((device) => device.isUpdatable).toList();
+        log.debug('${_devices.length} devices');
+        notifyListeners();
+      },
+      onError: (e) {
+        log.error('failed to get devices: $e');
+      },
+    );
   }
 
   @override

--- a/packages/firmware_updater/test/device_store_test.dart
+++ b/packages/firmware_updater/test/device_store_test.dart
@@ -115,4 +115,12 @@ void main() {
     final index = store.indexOf(devices[1].deviceId);
     expect(index, 1);
   });
+
+  test('no detected devices', () async {
+    final service = mockService();
+    final store = DeviceStore(service);
+    await store.init();
+
+    expect(store.devices, isEmpty);
+  });
 }

--- a/packages/firmware_updater/test/test_utils.dart
+++ b/packages/firmware_updater/test/test_utils.dart
@@ -44,7 +44,10 @@ MockFwupdDbusService mockService({
   Map<String, List<FwupdRelease>>? releases,
 }) {
   final service = MockFwupdDbusService();
-  when(service.getDevices()).thenAnswer((_) async => devices ?? []);
+  when(service.getDevices()).thenAnswer((_) async {
+    if (devices == null) throw const FwupdNothingToDoException();
+    return devices;
+  });
   when(service.getReleases(any)).thenAnswer((i) async {
     final device = i.positionalArguments[0] as FwupdDevice;
     final value = releases?[device.deviceId];


### PR DESCRIPTION
Fix #278