### PR TITLE
fix: Move logfile to snap-friendly location

### DIFF
--- a/packages/firmware_updater/lib/main.dart
+++ b/packages/firmware_updater/lib/main.dart
@@ -1,16 +1,26 @@
+import 'dart:io';
+
 import 'package:firmware_updater/firmware_app.dart';
 import 'package:firmware_updater/fwupd_dbus_service.dart';
 import 'package:firmware_updater/fwupd_mock_service.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:gtk/gtk.dart';
+import 'package:path/path.dart' as p;
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:xdg_directories/xdg_directories.dart' as xdg;
 import 'package:yaru/yaru.dart';
 
 Future<void> main(List<String> args) async {
-  Logger.setup(level: LogLevel.fromString(kDebugMode ? 'debug' : 'info'));
+  final binaryName = p.basename(Platform.resolvedExecutable);
+  Logger.setup(
+    path: p.join(
+      xdg.dataHome.path,
+      binaryName,
+      '$binaryName.log',
+    ),
+  );
 
   for (final element in args) {
     if (element.startsWith('--simulate=')) {

--- a/packages/firmware_updater/pubspec.yaml
+++ b/packages/firmware_updater/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   ubuntu_service: ^0.3.0
   ubuntu_test: ^0.1.0-beta.4
   upower: ^0.7.0
+  xdg_directories: ^1.0.4
   yaml: ^3.1.2
   yaru: ^1.1.0
   yaru_colors: ^0.1.7


### PR DESCRIPTION
Copy the same logfile location as app-center:
  ~/.local/share/$NAME
which inside snap resolves to:
  /home/$USER/snap/$NAME/current/.local/share/$NAME

Also remove the debug level logic because that duplicates the
default behaviour.

Fixes: #242 