### PR TITLE
 Feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -47,8 +47,6 @@ body:
     options:
       - '24.10'
       - 24.04 LTS
-      - 22.04 LTS
-      - 20.04 LTS
       - Other (specify in the last field)
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -66,7 +66,7 @@ body:
     label: System info
     description: |
       Please run this command in your terminal:
-      ```uname -rv && snap info firmware-updater```
+      ```uname -rv && snap info firmware-updater snapd```
       and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,82 @@
+name: Bug report for the Firmware Updater
+description: Create a report to help us improve
+labels:
+  - bug
+assignees:
+  - d-loose
+  - sminez
+  - matthew-hagemann
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: |
+      Please search to see if an issue already exists for this feature: https://github.com/canonical/firmware-updater/issues.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: |
+      A clear and concise description of what the bug is. You can also attach screenshots or recordings.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps to reproduce the behavior
+    placeholder: |
+      1. Go to '...'
+      2. Click on '....'
+      3. Scroll down to '....'
+      4. See error
+  validations:
+    required: false
+- type: textarea
+  id: expected_behavior
+  attributes:
+    label: Expected behavior
+    description: |
+      A clear and concise description of what you expected to happen.
+  validations:
+    required: false
+- type: dropdown
+  attributes:
+    label: Ubuntu release
+    description: What version of our Ubuntu are you running?
+    options:
+      - '24.10'
+      - 24.04 LTS
+      - 22.04 LTS
+      - 20.04 LTS
+      - Other (specify in the last field)
+  validations:
+    required: false
+- type: dropdown
+  attributes:
+    label: What architecture are you using?
+    multiple: false
+    options:
+      - amd64
+      - arm64
+      - Other (specify in the last field)
+      - I don't know
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: System info
+    description: |
+      Please run this command in your terminal:
+      ```uname -rv && snap info firmware-updater```
+      and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional context
+    description: |
+      You can attach screenshots, recordings, logs, or any other information that you think might be helpful. Please remember to anonymize any personal data.
+  validations:
+    required: false
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug report for the Firmware Updater
-description: Create a report to help us improve
+description: Report an issue to help the development
 labels:
   - bug
 assignees:
@@ -11,17 +11,17 @@ body:
   attributes:
     label: Is there an existing issue for this?
     description: |
-      Please search to see if an issue already exists for this feature: https://github.com/canonical/firmware-updater/issues.
+      Please check whether an issue already exists for this feature: https://github.com/canonical/ubuntu-desktop-provision/issues.
     options:
-    - label: I have searched the existing issues
+    - label: I have searched the existing issues and found none matching what I'm reporting.
       required: true
 - type: textarea
   attributes:
-    label: Describe the bug
+    label: Bug Description
     description: |
-      A clear and concise description of what the bug is. You can also attach screenshots or recordings.
+      Describe the bug clearly and concisely. Include what is the bug and attach screenshots or recordings if needed.
   validations:
-    required: false
+    required: true 
 - type: textarea
   attributes:
     label: Steps to reproduce the behavior
@@ -31,7 +31,7 @@ body:
       3. Scroll down to '....'
       4. See error
   validations:
-    required: false
+    required: true 
 - type: textarea
   id: expected_behavior
   attributes:

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contact Canonical
+    url: https://ubuntu.com/contact-us/form
+    about: Contact us to get more information
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest an idea for the Firmware Updater
+labels:
+  - enhancement
+assignees:
+  - d-loose
+  - sminez
+  - matthew-hagemann
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: |
+      Please search to see if an issue already exists for this feature: https://github.com/canonical/firmware-updater/issues?q=label%3Aenhancement.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Is the feature related to a problem or existing issue?
+    description: |
+      If so, please describe the problem or reference/link the issue number. If not, leave this empty.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Describe the solution/feature you'd like.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe any alternatives you've considered.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional context
+    description: |
+      Provide any additional context that may be relevant to the feature request.
+  validations:
+    required: false
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -11,9 +11,9 @@ body:
   attributes:
     label: Is there an existing issue for this?
     description: |
-      Please search to see if an issue already exists for this feature: https://github.com/canonical/firmware-updater/issues?q=label%3Aenhancement.
+      Please check whether an issue already exists for this feature: https://github.com/canonical/firmware-updater/issues?q=label%3Aenhancement.
     options:
-    - label: I have searched the existing issues
+    - label: I have searched the existing issues and found none matching what I'm reporting.
       required: true
 - type: textarea
   attributes:
@@ -24,7 +24,7 @@ body:
     required: false
 - type: textarea
   attributes:
-    label: Describe the solution/feature you'd like.
+    label: Describe the feature, why the feature matters to you, and what benefits the feature will bring about.
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
Adds issue templates for bug reports and enhancement.

You can preview what these options look like on my branch [here](https://github.com/matthew-hagemann/firmware-updater/issues/new/choose)