### PR TITLE
fix: exempt 'weblate' from cla check

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   cla-check:
+    if: github.event.pull_request.user.login != 'weblate'
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed


### PR DESCRIPTION
It looks like the updated CLA check (#333) does not automatically exclude [weblate](https://github.com/weblate) as it's not a proper bot account.