### PR TITLE
feat: add FDE documentation link to confirmation dialog

### DIFF
--- a/apps/firmware_updater/lib/l10n/app_en.arb
+++ b/apps/firmware_updater/lib/l10n/app_en.arb
@@ -4,6 +4,7 @@
   "affectsFdeWarningBody1": "Make sure you have recovery keys for all your encrypted drives. You will need to enter them on boot after updating firmware.",
   "affectsFdeWarningBody2": "You need recovery keys because you have enabled hardware-backed encryption in Ubuntu or other operating systems on this computer.",
   "affectsFdeCheckbox": "I have recovery keys for all my encrypted drives",
+  "affectsFdeLinkLabel": "Learn more",
   "allVersions": "All Versions",
   "appTitle": "Firmware Updater",
   "batteryWarning": "Warning: some device updates may only be available on external power!",

--- a/apps/firmware_updater/lib/widgets/dialogs.dart
+++ b/apps/firmware_updater/lib/widgets/dialogs.dart
@@ -3,11 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:fwupd/fwupd.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
 
 enum DialogAction { primaryAction, secondaryAction, cancel, close }
 
 const kMaxWidth = 500.0;
+const fdeLink =
+    'https://discourse.ubuntu.com/t/hardware-backed-encryption-and-recovery-keys-in-ubuntu-desktop/58243';
 
 Future<DialogAction?> showGeneralDialog(
   BuildContext context, {
@@ -349,6 +352,19 @@ void confirmAndInstall(
             Text(l10n.affectsFdeWarningBody1),
             const SizedBox(height: 8),
             Text(l10n.affectsFdeWarningBody2),
+            MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: () => launchUrlString(fdeLink),
+                child: Text(
+                  l10n.affectsFdeLinkLabel,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium!
+                      .copyWith(color: Theme.of(context).colorScheme.link),
+                ),
+              ),
+            ),
           ],
         ),
       ),

--- a/apps/firmware_updater/pubspec.lock
+++ b/apps/firmware_updater/pubspec.lock
@@ -935,6 +935,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.14"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   vector_graphics:
     dependency: transitive
     description:

--- a/apps/firmware_updater/pubspec.yaml
+++ b/apps/firmware_updater/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   ubuntu_service: ^0.4.0
   ubuntu_test: ^0.2.0
   upower: ^0.7.0
+  url_launcher: ^6.3.1
   xdg_directories: ^1.0.4
   yaml: ^3.1.2
   yaru: ^5.0.0


### PR DESCRIPTION
![Screenshot From 2025-04-16 15-20-13](https://github.com/user-attachments/assets/8abf5dc6-88da-4010-9fa3-c97567924697)

I added a text widget with the link color and a gesture detector, since I couldn't get the `Html` widget we use elsewhere to work within the dialog:

```
The following assertion was thrown during performLayout():
The RenderCSSBox class does not implement "computeDryBaseline".
If you are not writing your own RenderBox subclass, then this is
not
your fault. Contact support:
https://github.com/flutter/flutter/issues/new?template=2_bug.yml

The relevant error-causing widget was:
  AlertDialog
```

UDENG-6588