### PR TITLE
fix: regenerate l10n strings

### DIFF
--- a/apps/firmware_updater/lib/l10n/app_localizations.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations.dart
@@ -263,6 +263,12 @@ abstract class AppLocalizations {
   /// **'I have recovery keys for all my encrypted drives'**
   String get affectsFdeCheckbox;
 
+  /// No description provided for @affectsFdeLinkLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Learn more'**
+  String get affectsFdeLinkLabel;
+
   /// No description provided for @allVersions.
   ///
   /// In en, this message translates to:

--- a/apps/firmware_updater/lib/l10n/app_localizations_am.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_am.dart
@@ -21,6 +21,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ar.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ar.dart
@@ -21,6 +21,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_be.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_be.dart
@@ -21,6 +21,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Усе версіі';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_bg.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_bg.dart
@@ -21,6 +21,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_bn.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_bn.dart
@@ -21,6 +21,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_bo.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_bo.dart
@@ -21,6 +21,9 @@ class AppLocalizationsBo extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_bs.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_bs.dart
@@ -21,6 +21,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ca.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ca.dart
@@ -21,6 +21,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Totes les versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_cs.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_cs.dart
@@ -21,6 +21,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get affectsFdeCheckbox => 'Mám klíče pro obnovení pro všechny své šifrované disky';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Všechny verze';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_cy.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_cy.dart
@@ -21,6 +21,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_da.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_da.dart
@@ -21,6 +21,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Alle versioner';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_de.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_de.dart
@@ -21,6 +21,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get affectsFdeCheckbox => 'Ich habe Wiederherstellungsschlüssel für alle meine verschlüsselten Laufwerke';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Alle Versionen';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_dz.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_dz.dart
@@ -21,6 +21,9 @@ class AppLocalizationsDz extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_el.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_el.dart
@@ -21,6 +21,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_en.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_en.dart
@@ -21,6 +21,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_eo.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_eo.dart
@@ -21,6 +21,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get affectsFdeCheckbox => 'Mi havas restaŭrajn ŝlosilojn por ĉiuj ĉifritaj diskoj';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Ĉiuj versioj';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_es.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_es.dart
@@ -21,6 +21,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get affectsFdeCheckbox => 'Tengo claves de recuperación para todas mis unidades cifradas';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Todas las versiones';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_et.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_et.dart
@@ -21,6 +21,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get affectsFdeCheckbox => 'Mul on taastevõtmed kõikide minu krüptitud andmekandjate jaoks';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Kõik versioonid';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_eu.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_eu.dart
@@ -21,6 +21,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_fa.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_fa.dart
@@ -21,6 +21,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_fi.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_fi.dart
@@ -21,6 +21,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Kaikki versiot';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_fr.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_fr.dart
@@ -21,6 +21,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get affectsFdeCheckbox => 'J’ai les clés de récupération pour tous mes disques cryptés';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Toutes les versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ga.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ga.dart
@@ -21,6 +21,9 @@ class AppLocalizationsGa extends AppLocalizations {
   String get affectsFdeCheckbox => 'Tá eochracha athshlánaithe agam do mo thiomáineann criptithe go léir';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Gach Leagan';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_gl.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_gl.dart
@@ -21,6 +21,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_gu.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_gu.dart
@@ -21,6 +21,9 @@ class AppLocalizationsGu extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_he.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_he.dart
@@ -21,6 +21,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get affectsFdeCheckbox => 'יש לי מפתחות שחזור לכל הכוננים המוצפנים שלי';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'כל הגרסאות';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_hi.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_hi.dart
@@ -21,6 +21,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_hr.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_hr.dart
@@ -21,6 +21,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_hu.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_hu.dart
@@ -21,6 +21,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get affectsFdeCheckbox => 'Rendelkezem helyreállítási kulcsokkal az összes titkosított meghajtómhoz';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Összes verzió';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_id.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_id.dart
@@ -21,6 +21,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get affectsFdeCheckbox => 'Saya memiliki kunci pemulihan untuk semua drive terenkripsi saya';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Semua versi';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_is.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_is.dart
@@ -21,6 +21,9 @@ class AppLocalizationsIs extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_it.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_it.dart
@@ -21,6 +21,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Tutte le versioni';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ja.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ja.dart
@@ -21,6 +21,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'すべてのバージョン';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ka.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ka.dart
@@ -21,6 +21,9 @@ class AppLocalizationsKa extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'ყველა ვერსია';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_kk.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_kk.dart
@@ -21,6 +21,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_km.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_km.dart
@@ -21,6 +21,9 @@ class AppLocalizationsKm extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_kn.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_kn.dart
@@ -21,6 +21,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ko.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ko.dart
@@ -21,6 +21,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get affectsFdeCheckbox => '모든 암호화된 드라이브에 대한 복구 키를 보유하고 있습니다';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => '모든 버전';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ku.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ku.dart
@@ -21,6 +21,9 @@ class AppLocalizationsKu extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_lo.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_lo.dart
@@ -21,6 +21,9 @@ class AppLocalizationsLo extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_lt.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_lt.dart
@@ -21,6 +21,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Visos versijos';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_lv.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_lv.dart
@@ -21,6 +21,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_mk.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_mk.dart
@@ -21,6 +21,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ml.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ml.dart
@@ -21,6 +21,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_mr.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_mr.dart
@@ -21,6 +21,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_my.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_my.dart
@@ -21,6 +21,9 @@ class AppLocalizationsMy extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_nb.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_nb.dart
@@ -21,6 +21,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Alle versjoner';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ne.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ne.dart
@@ -21,6 +21,9 @@ class AppLocalizationsNe extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_nl.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_nl.dart
@@ -21,6 +21,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get affectsFdeCheckbox => 'Ik heb herstelcodes voor al mijn versleutelde schijven';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Alle Versies';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_nn.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_nn.dart
@@ -21,6 +21,9 @@ class AppLocalizationsNn extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_oc.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_oc.dart
@@ -21,6 +21,9 @@ class AppLocalizationsOc extends AppLocalizations {
   String get affectsFdeCheckbox => 'Ai las claus de recuperacion per totes mos disques chifras';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Totas las versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_pa.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_pa.dart
@@ -21,6 +21,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_pl.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_pl.dart
@@ -21,6 +21,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get affectsFdeCheckbox => 'Mam klucze odzyskiwania do wszystkich moich zaszyfrowanych dysków';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Wszystkie wersje';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_pt.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_pt.dart
@@ -21,6 +21,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Todas as versões';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ro.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ro.dart
@@ -21,6 +21,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ru.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ru.dart
@@ -21,6 +21,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get affectsFdeCheckbox => 'У меня есть ключи восстановления для всех моих зашифрованных дисков';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Все версии';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_se.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_se.dart
@@ -21,6 +21,9 @@ class AppLocalizationsSe extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_si.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_si.dart
@@ -21,6 +21,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_sk.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_sk.dart
@@ -21,6 +21,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get affectsFdeCheckbox => 'Pre všetky moje šifrované disky mám kľúče na obnovenie';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Všetky verzie';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_sl.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_sl.dart
@@ -21,6 +21,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_sq.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_sq.dart
@@ -21,6 +21,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_sr.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_sr.dart
@@ -21,6 +21,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Све верзије';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_sv.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_sv.dart
@@ -21,6 +21,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get affectsFdeCheckbox => 'Jag har återställningsnycklar för alla mina krypterade enheter';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Alla versioner';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ta.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ta.dart
@@ -21,6 +21,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get affectsFdeCheckbox => 'எனது அனைத்து மறைகுறியாக்கப்பட்ட இயக்கிகளுக்கும் மீட்பு விசைகள் உள்ளன';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'அனைத்து பதிப்புகளும்';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_te.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_te.dart
@@ -21,6 +21,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_tg.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_tg.dart
@@ -21,6 +21,9 @@ class AppLocalizationsTg extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_th.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_th.dart
@@ -21,6 +21,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'รุ่นทั้งหมด';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_tl.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_tl.dart
@@ -21,6 +21,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_tr.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_tr.dart
@@ -21,6 +21,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Tüm Sürümler';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_ug.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_ug.dart
@@ -21,6 +21,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_uk.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_uk.dart
@@ -21,6 +21,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get affectsFdeCheckbox => 'У мене є ключі відновлення для всіх моїх зашифрованих дисків';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'Всі версії';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_vi.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_vi.dart
@@ -21,6 +21,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get affectsFdeCheckbox => 'I have recovery keys for all my encrypted drives';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => 'All Versions';
 
   @override

--- a/apps/firmware_updater/lib/l10n/app_localizations_zh.dart
+++ b/apps/firmware_updater/lib/l10n/app_localizations_zh.dart
@@ -21,6 +21,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get affectsFdeCheckbox => '我拥有我所有加密磁盘的恢复密钥';
 
   @override
+  String get affectsFdeLinkLabel => 'Learn more';
+
+  @override
   String get allVersions => '全部版本';
 
   @override


### PR DESCRIPTION
Looks like the l10n strings weren't properly regenerated when we updated the Flutter version. This should fix that.