### PR TITLE
feat: add snap interface to access snapd TPM FDE endpoints

### DIFF
--- a/apps/firmware_updater/lib/services/recovery_key_service.dart
+++ b/apps/firmware_updater/lib/services/recovery_key_service.dart
@@ -30,6 +30,9 @@ class RecoveryKeySnapdService implements RecoveryKeyService {
       _log.info('caught snapd exception $e');
       _log.info('assuming recovery key is invalid');
       return false;
+    } on Exception catch (e) {
+      _log.error(e);
+      rethrow;
     }
   }
 }

--- a/apps/firmware_updater/lib/services/recovery_key_service.dart
+++ b/apps/firmware_updater/lib/services/recovery_key_service.dart
@@ -17,7 +17,8 @@ class RecoveryKeyMockService implements RecoveryKeyService {
 
 class RecoveryKeySnapdService implements RecoveryKeyService {
   RecoveryKeySnapdService({@visibleForTesting SnapdClient? snapdClient})
-      : _snapdClient = snapdClient ?? SnapdClient();
+      : _snapdClient =
+            snapdClient ?? SnapdClient(socketPath: '/run/snapd-snap.socket');
   final SnapdClient _snapdClient;
 
   @override

--- a/apps/firmware_updater/lib/widgets/dialogs.dart
+++ b/apps/firmware_updater/lib/widgets/dialogs.dart
@@ -271,12 +271,17 @@ class _RecoveryKeyConfirmationDialogState
                     Navigator.of(context).pop(DialogAction.primaryAction);
                   }
                   _setLoading(true);
-                  final result = await model.checkRecoveryKey(_recoveryKey);
-                  if (!result) {
+                  try {
+                    final result = await model.checkRecoveryKey(_recoveryKey);
+                    if (!result) {
+                      _setLoading(false);
+                      _setError(l10n.affectsFdeIncorrectKey);
+                    } else if (context.mounted) {
+                      Navigator.of(context).pop(DialogAction.primaryAction);
+                    }
+                  } on Exception catch (e) {
                     _setLoading(false);
-                    _setError(l10n.affectsFdeIncorrectKey);
-                  } else if (context.mounted) {
-                    Navigator.of(context).pop(DialogAction.primaryAction);
+                    _setError(e.toString());
                   }
                 },
           child: Text(widget.actionText ?? l10n.ok),

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,6 +101,7 @@ apps:
       - fwupd
       - shutdown
       - upower-observe
+      - firmware-updater-support
 
   firmware-notifier:
     command: bin/firmware-notifier


### PR DESCRIPTION
Adds the `firmware-updater-support` interface to the snapcraft.yaml to allow users to access the recovery key check via a polkit prompt. See https://github.com/canonical/snapd/pull/15657

I've also added some minimal error handling to inform the user in case we can't connect to snapd.

UDENG-7387