### PR TITLE
feat: make fwupd test files accessible in the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,12 @@ slots:
     name: com.canonical.firmware_updater
     bus: session
 
+plugs:
+  hostfs-usr-share-installed-tests-fwupd:
+    interface: system-files
+    read:
+      - /var/lib/snapd/hostfs/usr/share/installed-tests/fwupd
+
 parts:
   flutter-git:
     plugin: nil
@@ -103,6 +109,7 @@ apps:
       - upower-observe
       - firmware-updater-support
       - udisks2
+      - hostfs-usr-share-installed-tests-fwupd
 
   firmware-notifier:
     command: bin/firmware-notifier

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,10 @@ plugs:
     read:
       - /var/lib/snapd/hostfs/usr/share/installed-tests/fwupd
 
+layout:
+  /usr/share/installed-tests:
+    bind: $SNAP/usr/share/installed-tests
+
 parts:
   flutter-git:
     plugin: nil
@@ -84,6 +88,9 @@ parts:
       cd apps/firmware_notifier
       mkdir -p $CRAFT_PART_INSTALL/bin/
       fvm dart compile exe bin/firmware_notifier.dart -o $CRAFT_PART_INSTALL/bin/firmware-notifier
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/share/installed-tests
+      ln -s /var/lib/snapd/hostfs/usr/share/installed-tests/fwupd $CRAFT_PART_INSTALL/usr/share/installed-tests/
 
   firmware-updater:
     plugin: dump


### PR DESCRIPTION
Makes the test files in `/usr/share/installed-tests/fwupd` from the `fwupd-tests` package readable in the snap environment using the `system-files` interface.

We'll need to file a store request for this, since the interface is super-privileged. We don't need to ask for auto-connect though, since it's only needed for end-to-end tests.

UDENG-7371