### PR TITLE
feat: exclude UEFI dbx from recovery key checks

### DIFF
--- a/apps/firmware_updater/lib/widgets/dialogs.dart
+++ b/apps/firmware_updater/lib/widgets/dialogs.dart
@@ -15,6 +15,9 @@ enum RecoveryKeyCheck { none, tickBox, enterKey }
 const kMaxWidth = 500.0;
 const fdeLink =
     'https://discourse.ubuntu.com/t/hardware-backed-encryption-and-recovery-keys-in-ubuntu-desktop/58243';
+const deviceIdsExcludedFromRecoveryKeyCheck = [
+  '362301da643102b9f38477387e2193e57abaa590', // UEFI dbx
+];
 
 Future<DialogAction?> showGeneralDialog(
   BuildContext context, {
@@ -395,7 +398,8 @@ void confirmAndInstall(
   final String actionText;
   final String dialogText;
 
-  final affectsFde = device.flags.contains(FwupdDeviceFlag.affectsFde) ||
+  final affectsFde = device.flags.contains(FwupdDeviceFlag.affectsFde) &&
+          !deviceIdsExcludedFromRecoveryKeyCheck.contains(device.deviceId) ||
       testDeviceAffectsFde &&
           // fwupd 'Fake webcam' test device
           device.deviceId == '08d460be0f1f9f128413f816022a6439e0078018';

--- a/apps/firmware_updater/test/device_page_test.dart
+++ b/apps/firmware_updater/test/device_page_test.dart
@@ -126,6 +126,7 @@ void main() {
       for (final testCase in [
         (
           name: 'Ubuntu FDE',
+          deviceId: null,
           hasUbuntuFde: true,
           hasBitlocker: false,
           expectTextField: true,
@@ -133,6 +134,7 @@ void main() {
         ),
         (
           name: 'Bitlocker',
+          deviceId: null,
           hasUbuntuFde: false,
           hasBitlocker: true,
           expectTextField: false,
@@ -140,15 +142,24 @@ void main() {
         ),
         (
           name: 'Other FDE',
+          deviceId: null,
           hasUbuntuFde: false,
           hasBitlocker: false,
           expectTextField: false,
           expectCheckBox: true,
         ),
+        (
+          name: 'UEFI dbx',
+          deviceId: '362301da643102b9f38477387e2193e57abaa590',
+          hasUbuntuFde: true,
+          hasBitlocker: false,
+          expectTextField: false,
+          expectCheckBox: false,
+        ),
       ]) {
         testWidgets(testCase.name, (tester) async {
           final device = testDevice(
-            id: 'a',
+            id: testCase.deviceId ?? 'a',
             version: '1.0.0',
             name: 'test device',
             flags: {FwupdDeviceFlag.affectsFde},


### PR DESCRIPTION
This explicitly disables the recovery key prompt for `UEFI dbx` updates, since snapd can predict the new PCR values in this case, so the recovery key is not needed on the next boot.

UDENG-7371