### PR TITLE
fix: show checkbox for UEFI dbx updates with non Ubuntu FDE

### DIFF
--- a/apps/firmware_updater/lib/widgets/dialogs.dart
+++ b/apps/firmware_updater/lib/widgets/dialogs.dart
@@ -284,6 +284,7 @@ class _RecoveryKeyConfirmationDialogState
               : () async {
                   if (widget.recoveryKeyCheck != RecoveryKeyCheck.enterKey) {
                     Navigator.of(context).pop(DialogAction.primaryAction);
+                    return;
                   }
                   _setLoading(true);
                   try {

--- a/apps/firmware_updater/lib/widgets/dialogs.dart
+++ b/apps/firmware_updater/lib/widgets/dialogs.dart
@@ -398,14 +398,17 @@ void confirmAndInstall(
   final String actionText;
   final String dialogText;
 
-  final affectsFde = device.flags.contains(FwupdDeviceFlag.affectsFde) &&
-          !deviceIdsExcludedFromRecoveryKeyCheck.contains(device.deviceId) ||
+  final affectsFde = device.flags.contains(FwupdDeviceFlag.affectsFde) ||
       testDeviceAffectsFde &&
           // fwupd 'Fake webcam' test device
           device.deviceId == '08d460be0f1f9f128413f816022a6439e0078018';
 
-  final recoveryKeyCheck = switch ((affectsFde, hasUbuntuFde, hasBitlocker)) {
-    (true, true, _) => RecoveryKeyCheck.enterKey,
+  final recoveryKeyCheck = switch ((
+    affectsFde,
+    hasUbuntuFde,
+    deviceIdsExcludedFromRecoveryKeyCheck.contains(device.deviceId),
+  )) {
+    (true, true, false) => RecoveryKeyCheck.enterKey,
     (true, false, _) => RecoveryKeyCheck.tickBox,
     _ => RecoveryKeyCheck.none
   };

--- a/apps/firmware_updater/test/device_page_test.dart
+++ b/apps/firmware_updater/test/device_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:firmware_updater/app.dart';
 import 'package:firmware_updater/pages.dart';
+import 'package:firmware_updater/recovery_key_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fwupd/fwupd.dart';
@@ -40,7 +41,7 @@ void main() {
           store: store,
         ),
         providers: [
-          Provider(create: (_) => recoveryKeyModel),
+          Provider<RecoveryKeyModel>(create: (_) => recoveryKeyModel),
         ],
       );
 
@@ -64,7 +65,7 @@ void main() {
           store: store,
         ),
         providers: [
-          Provider(create: (_) => recoveryKeyModel),
+          Provider<RecoveryKeyModel>(create: (_) => recoveryKeyModel),
         ],
       );
 
@@ -101,7 +102,7 @@ void main() {
       await tester.pumpApp(
         (_) => buildPage(model: model, notifier: notifier, store: store),
         providers: [
-          Provider(create: (_) => recoveryKeyModel),
+          Provider<RecoveryKeyModel>(create: (_) => recoveryKeyModel),
         ],
       );
 
@@ -205,7 +206,7 @@ void main() {
           await tester.pumpApp(
             (_) => buildPage(model: model, notifier: notifier, store: store),
             providers: [
-              Provider(create: (_) => recoveryKeyModel),
+              Provider<RecoveryKeyModel>(create: (_) => recoveryKeyModel),
             ],
           );
 
@@ -261,6 +262,8 @@ void main() {
           await tester.tap(find.text(tester.lang.update));
           if (testCase.expectTextField) {
             verify(recoveryKeyModel.checkRecoveryKey('recovery key')).called(1);
+          } else {
+            verifyNever(recoveryKeyModel.checkRecoveryKey(any));
           }
           verify(model.install(releases[0])).called(1);
         });
@@ -280,7 +283,7 @@ void main() {
       await tester.pumpApp(
         (_) => buildPage(model: model, notifier: notifier, store: store),
         providers: [
-          Provider(create: (_) => recoveryKeyModel),
+          Provider<RecoveryKeyModel>(create: (_) => recoveryKeyModel),
         ],
       );
 
@@ -317,7 +320,7 @@ void main() {
       await tester.pumpApp(
         (_) => buildPage(model: model, notifier: notifier, store: store),
         providers: [
-          Provider(create: (_) => recoveryKeyModel),
+          Provider<RecoveryKeyModel>(create: (_) => recoveryKeyModel),
         ],
       );
 

--- a/apps/firmware_updater/test/device_page_test.dart
+++ b/apps/firmware_updater/test/device_page_test.dart
@@ -149,12 +149,28 @@ void main() {
           expectCheckBox: true,
         ),
         (
-          name: 'UEFI dbx',
+          name: 'UEFI dbx - Ubuntu FDE',
           deviceId: '362301da643102b9f38477387e2193e57abaa590',
           hasUbuntuFde: true,
           hasBitlocker: false,
           expectTextField: false,
           expectCheckBox: false,
+        ),
+        (
+          name: 'UEFI dbx - Bitlocker',
+          deviceId: '362301da643102b9f38477387e2193e57abaa590',
+          hasUbuntuFde: false,
+          hasBitlocker: true,
+          expectTextField: false,
+          expectCheckBox: true,
+        ),
+        (
+          name: 'UEFI dbx - Other FDE',
+          deviceId: '362301da643102b9f38477387e2193e57abaa590',
+          hasUbuntuFde: false,
+          hasBitlocker: false,
+          expectTextField: false,
+          expectCheckBox: true,
         ),
       ]) {
         testWidgets(testCase.name, (tester) async {
@@ -206,14 +222,16 @@ void main() {
             findsOneWidget,
           );
 
+          final textField = find.byType(TextField);
           if (testCase.expectTextField) {
-            final textField = find.byType(TextField);
             await tester.enterText(textField, 'recovery key');
             await tester.pumpAndSettle();
-            await tester.tap(find.text(tester.lang.update));
-            verify(recoveryKeyModel.checkRecoveryKey('recovery key')).called(1);
-            verify(model.install(releases[0])).called(1);
-          } else if (testCase.expectCheckBox) {
+          } else {
+            expect(textField, findsNothing);
+          }
+
+          final checkbox = find.byType(YaruCheckbox);
+          if (testCase.expectCheckBox) {
             expect(
               tester
                   .widget<ElevatedButton>(
@@ -223,7 +241,6 @@ void main() {
               isFalse,
             );
 
-            final checkbox = find.byType(YaruCheckbox);
             expect(checkbox, findsOneWidget);
 
             await tester.tap(checkbox);
@@ -237,10 +254,15 @@ void main() {
                   .enabled,
               isTrue,
             );
-
-            await tester.tap(find.text(tester.lang.update));
-            verify(model.install(releases[0])).called(1);
+          } else {
+            expect(checkbox, findsNothing);
           }
+
+          await tester.tap(find.text(tester.lang.update));
+          if (testCase.expectTextField) {
+            verify(recoveryKeyModel.checkRecoveryKey('recovery key')).called(1);
+          }
+          verify(model.install(releases[0])).called(1);
         });
       }
     });

--- a/apps/firmware_updater/test/release_page_test.dart
+++ b/apps/firmware_updater/test/release_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:firmware_updater/app.dart';
 import 'package:firmware_updater/pages.dart';
+import 'package:firmware_updater/recovery_key_model.dart' show RecoveryKeyModel;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fwupd/fwupd.dart';
@@ -55,7 +56,7 @@ void main() {
         store: store,
       ),
       providers: [
-        Provider(create: (_) => recoveryKeyModel),
+        Provider<RecoveryKeyModel>(create: (_) => recoveryKeyModel),
       ],
     );
 

--- a/apps/firmware_updater/test/test_utils.dart
+++ b/apps/firmware_updater/test/test_utils.dart
@@ -78,7 +78,7 @@ MockFwupdDbusService mockService({
 DeviceStore mockStore() => MockDeviceStore();
 
 @GenerateMocks([RecoveryKeyModel])
-RecoveryKeyModel mockRecoveryKeyModel({
+MockRecoveryKeyModel mockRecoveryKeyModel({
   String? validKey,
   bool? hasUbuntuFde,
   bool? hasBitlocker,

--- a/apps/firmware_updater/test/widgets/message_dialog_test.dart
+++ b/apps/firmware_updater/test/widgets/message_dialog_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:firmware_updater/recovery_key_model.dart';
 import 'package:firmware_updater/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -149,7 +150,7 @@ void main() {
           child: const Text('click me'),
         ),
       ),
-      providers: [Provider(create: (_) => recoveryKeyModel)],
+      providers: [Provider<RecoveryKeyModel>(create: (_) => recoveryKeyModel)],
     );
     await tester.tap(find.text('click me'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
While continuing with the e2e tests, I realized that we still need to show a checkbox for `UEFI dbx` updates in the case of Bitlocker or any other non-Ubuntu FDE. I've also adapted the widget tests to be more explicit.