### PR TITLE
fix: rely on FWUPD_RELEASE_FLAG_IS_UPGRADE for 'update available' chip

### DIFF
--- a/apps/firmware_updater/lib/pages/device_page.dart
+++ b/apps/firmware_updater/lib/pages/device_page.dart
@@ -67,9 +67,7 @@ class DevicePage extends StatelessWidget {
                       DevicePage._buildLabel(
                         context,
                         model.latestRelease!.version,
-                        model.latestRelease!.version != model.device.version
-                            ? l10n.updateAvailable
-                            : null,
+                        model.hasUpgrade ? l10n.updateAvailable : null,
                       ),
                     ],
                   ),


### PR DESCRIPTION
See #362 - we shouldn't manually compare version strings if we have access to a flag that indicates whether an update is available or not.