### PR TITLE
feat: Reapply "snap: core24 migration"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,13 +3,13 @@ version: git
 summary: Firmware Updater
 description: Update Firmware
 confinement: strict
-base: core22
+base: core24
 grade: stable
 license: GPL-3.0+
 icon: snap/local/firmware-updater.png
-architectures:
-  - build-on: amd64
-  - build-on: arm64
+platforms:
+  amd64:
+  arm64:
 
 slots:
   dbus-slot:
@@ -29,6 +29,7 @@ parts:
       - clang
       - cmake
       - curl
+      - git
       - libgtk-3-dev
       - ninja-build
       - unzip


### PR DESCRIPTION
Updates the snap to core24. This was previously done in #304 but had to be reverted in #310.

This reverts commit 2ea9c03deae296d13a4e3a646ce8f09c0317124e.

UDENG-8515