### PR TITLE
chore: fix fvm install script

### DIFF
--- a/scripts/install-fvm.sh
+++ b/scripts/install-fvm.sh
@@ -54,7 +54,7 @@ fi
 
 # Define the URL of the FVM binary
 if [ -z "$1" ]; then
-  FVM_VERSION=$(curl -s https://api.github.com/repos/leoafarias/fvm/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  FVM_VERSION=$(curl -Ls https://api.github.com/repos/leoafarias/fvm/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
   if [ -z "$FVM_VERSION" ]; then
       error "Failed to fetch latest FVM version."
   fi


### PR DESCRIPTION
The snap builds started failing suddenly because the fvm install script couldn't figure out the latest version. Looks like this is due to a small change in the github API where the endpoint now returns 301. Adding `-L` to the `curl` command fixes the issue.