### PR TITLE
application: Use a transparent background as view bg color

### DIFF
--- a/apps/firmware_updater/linux/my_application.cc
+++ b/apps/firmware_updater/linux/my_application.cc
@@ -65,6 +65,10 @@ static void my_application_activate(GApplication* application) {
       project, self->dart_entrypoint_arguments);
 
   FlView* view = fl_view_new(project);
+
+  const GdkRGBA bg_color{};
+  fl_view_set_background_color(view, &bg_color);
+
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));


### PR DESCRIPTION
Flutter apps will draw by default using a black background, this is because it cannot be known what will be the application main color before than drawing it.

For flutter apps that are using the yaru toolkit we can be confident that the bg color will match the gtk one so we can just show a transparent background rather than painting a black one while the app is loading